### PR TITLE
Offload team activity calculations to MySQL

### DIFF
--- a/controllers/TeamController.php
+++ b/controllers/TeamController.php
@@ -35,12 +35,7 @@ class TeamController extends CRUDController
 
     public function listAction(Request $request)
     {
-        Team::$cachedMatches = Match::getQueryBuilder()
-            ->where('time')->isAfter(TimeDate::from('45 days ago'))
-            ->active()
-            ->getModels($fast = true);
-
-        $teamQB = $this->getQueryBuilder()
+        $teamQB = Team::getQueryBuilder()
             ->active()
             ->sortBy('elo')->reverse()
         ;
@@ -53,10 +48,10 @@ class TeamController extends CRUDController
             ->addToCache()
         ;
 
-        return array(
-            "teams"   => $teamQB->getModels($fast = true),
-            'showAll' => (bool)$request->get('showAll', false)
-        );
+        return [
+            'teams'   => $teamQB->withMatchActivity()->getModels($fast = true),
+            'showAll' => (bool)$request->get('showAll', false),
+        ];
     }
 
     public function createAction(Player $me)

--- a/migrations/20171002153825_drop_team_activity.php
+++ b/migrations/20171002153825_drop_team_activity.php
@@ -1,0 +1,18 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class DropTeamActivity extends AbstractMigration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function change()
+    {
+        $table = $this->table('teams');
+        $table
+            ->removeColumn('activity')
+            ->update()
+        ;
+    }
+}

--- a/src/QueryBuilder/MatchActivityQueryBuilder.php
+++ b/src/QueryBuilder/MatchActivityQueryBuilder.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @property BaseModel $type
+ */
+class MatchActivityQueryBuilder extends QueryBuilder
+{
+    protected function includeMatchActivity($selectColumns, $leftJoinOn)
+    {
+        $type = $this->type;
+        $columns = $type::getEagerColumns($this->getFromAlias());
+
+        $this->columns['activity'] = 'activity';
+        $this->extraColumns = 'SUM(m2.activity) AS activity';
+        $this->extras .= '
+          LEFT JOIN
+            (SELECT
+              m.id,'
+              . implode(',', $selectColumns) . ',
+              TIMESTAMPDIFF(SECOND, timestamp, NOW()) / 86400 AS days_passed,
+              (0.0116687059537612 * (POW((45 - LEAST((SELECT days_passed), 45)), (1/6)) + ATAN(31 - (SELECT days_passed)) / 2)) AS activity
+            FROM
+              matches m
+            WHERE
+              DATEDIFF(NOW(), timestamp) <= 45
+            ORDER BY
+              timestamp DESC) m2 ON ' . $leftJoinOn
+        ;
+
+        $this->groupQuery = 'GROUP BY ' . $columns;
+
+        return $this;
+    }
+}

--- a/src/QueryBuilder/PlayerQueryBuilder.php
+++ b/src/QueryBuilder/PlayerQueryBuilder.php
@@ -1,31 +1,12 @@
 <?php
 
-class PlayerQueryBuilder extends QueryBuilder
+class PlayerQueryBuilder extends MatchActivityQueryBuilder
 {
     public function withMatchActivity()
     {
-        $type = $this->type;
-        $columns = $type::getEagerColumns($this->getFromAlias());
-
-        $this->columns['activity'] = 'activity';
-        $this->extraColumns = 'SUM(m2.activity) AS activity';
-        $this->extras .= '
-          LEFT JOIN
-            (SELECT
-              m.id,
-              m.team_a_players,
-              m.team_b_players,
-              TIMESTAMPDIFF(SECOND, timestamp, NOW()) / 86400 AS days_passed,
-              (0.0116687059537612 * (POW((45 - LEAST((SELECT days_passed), 45)), (1/6)) + ATAN(31 - (SELECT days_passed)) / 2)) AS activity
-            FROM
-              matches m
-            WHERE
-              DATEDIFF(NOW(), timestamp) <= 45
-            ORDER BY
-              timestamp DESC) m2 ON FIND_IN_SET(players.id, m2.team_a_players) OR FIND_IN_SET(players.id, m2.team_b_players)
-        ';
-        $this->groupQuery = 'GROUP BY ' . $columns;
-
-        return $this;
+        return $this->includeMatchActivity(
+            ['m.team_a_players', 'm.team_b_players'],
+            'FIND_IN_SET(players.id, m2.team_a_players) OR FIND_IN_SET(players.id, m2.team_b_players)'
+        );
     }
 }

--- a/src/QueryBuilder/TeamQueryBuilder.php
+++ b/src/QueryBuilder/TeamQueryBuilder.php
@@ -1,32 +1,12 @@
 <?php
 
-class TeamQueryBuilder extends QueryBuilder
+class TeamQueryBuilder extends MatchActivityQueryBuilder
 {
     public function withMatchActivity()
     {
-        /** @var BaseModel $type */
-        $type = $this->type;
-        $columns = $type::getEagerColumns($this->getFromAlias());
-
-        $this->columns['activity'] = 'activity';
-        $this->extraColumns = 'SUM(m2.activity) AS activity';
-        $this->extras .= '
-          LEFT JOIN
-            (SELECT
-              m.id,
-              m.team_a,
-              m.team_b,
-              TIMESTAMPDIFF(SECOND, timestamp, NOW()) / 86400 AS days_passed,
-              (0.0116687059537612 * (POW((45 - LEAST((SELECT days_passed), 45)), (1/6)) + ATAN(31 - (SELECT days_passed)) / 2)) AS activity
-            FROM
-              matches m
-            WHERE
-              DATEDIFF(NOW(), timestamp) <= 45 AND m.match_type = "official"
-            ORDER BY
-              timestamp DESC) m2 ON teams.id = m2.team_a OR teams.id = m2.team_b
-        ';
-        $this->groupQuery = 'GROUP BY ' . $columns;
-
-        return $this;
+        return $this->includeMatchActivity(
+            ['m.team_a', 'm.team_b'],
+            'teams.id = m2.team_a OR teams.id = m2.team_b'
+        );
     }
 }

--- a/src/QueryBuilder/TeamQueryBuilder.php
+++ b/src/QueryBuilder/TeamQueryBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+class TeamQueryBuilder extends QueryBuilder
+{
+    public function withMatchActivity()
+    {
+        /** @var BaseModel $type */
+        $type = $this->type;
+        $columns = $type::getEagerColumns($this->getFromAlias());
+
+        $this->columns['activity'] = 'activity';
+        $this->extraColumns = 'SUM(m2.activity) AS activity';
+        $this->extras .= '
+          LEFT JOIN
+            (SELECT
+              m.id,
+              m.team_a,
+              m.team_b,
+              TIMESTAMPDIFF(SECOND, timestamp, NOW()) / 86400 AS days_passed,
+              (0.0116687059537612 * (POW((45 - LEAST((SELECT days_passed), 45)), (1/6)) + ATAN(31 - (SELECT days_passed)) / 2)) AS activity
+            FROM
+              matches m
+            WHERE
+              DATEDIFF(NOW(), timestamp) <= 45 AND m.match_type = "official"
+            ORDER BY
+              timestamp DESC) m2 ON teams.id = m2.team_a OR teams.id = m2.team_b
+        ';
+        $this->groupQuery = 'GROUP BY ' . $columns;
+
+        return $this;
+    }
+}

--- a/tests/ControllerTests/LeagueOverseerHookTest.php
+++ b/tests/ControllerTests/LeagueOverseerHookTest.php
@@ -530,7 +530,7 @@ class LeagueOverseerHookTest extends TestCase
             'teamOneColor' => 'Red',
             'teamTwoColor' => 'Purple',
             'duration' => 30,
-            'matchTime' => '17-08-01 13:00:00',
+            'matchTime' => TimeDate::now()->format(\DATE_ATOM),
             'server' => 'localhost:5154',
             'port' => 5154,
             'replayFile' => 'my-replay-file.rec',


### PR DESCRIPTION
Same thing as with player activity calculations, let's offload these calculations to MySQL instead of caching all of the matches and calculating them in PHP.

Additionally, team captains are now fetched ahead of time all together instead of making separate calls for each player model.