### PR TITLE
Add Seasons page with leaderboard and other stuff

### DIFF
--- a/app/routes.yml
+++ b/app/routes.yml
@@ -235,8 +235,11 @@ search_player_by_bzid:
     defaults: { _controller: 'Search', _action: 'playerByBzid', bzid: ~ }
 
 season_show:
-    path:     /season/{season}
-    defaults: { _controller: 'Season', _action: 'show', season: 'current' }
+    path:     /season/{period}-{year}
+    defaults: { _controller: 'Season', _action: 'show', period: 'current', year: 'current' }
+    requirements:
+        period: winter|spring|summer|fall
+        year: \d{4}
 
 server_list:
     path:     /servers

--- a/app/routes.yml
+++ b/app/routes.yml
@@ -234,6 +234,10 @@ search_player_by_bzid:
     path:    /search/players/bzid/{bzid}
     defaults: { _controller: 'Search', _action: 'playerByBzid', bzid: ~ }
 
+season_show:
+    path:     /season/{season}
+    defaults: { _controller: 'Season', _action: 'show', season: 'current' }
+
 server_list:
     path:     /servers
     defaults: { _controller: 'Server', _action: 'list' }

--- a/controllers/SeasonController.php
+++ b/controllers/SeasonController.php
@@ -1,0 +1,91 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+
+class SeasonController extends HTMLController
+{
+    public function showAction($season, Request $request)
+    {
+        $term = $year = '';
+        $this->parseSeason($season, $term, $year);
+
+        // Because this query can't be created efficiently using our QueryBuilder, let's do things manually
+        $db = Database::getInstance();
+        $seasonQuery = sprintf('
+            SELECT %s, e.elo_new AS elo FROM players p 
+              INNER JOIN player_elo e ON e.user_id = p.id 
+              INNER JOIN (
+                SELECT
+                  user_id, 
+                  MAX(match_id) AS last_match 
+                FROM
+                  player_elo 
+                WHERE
+                  season_period = ? AND season_year = ?
+                GROUP BY
+                  user_id
+              ) i ON i.user_id = p.id AND i.last_match = e.match_id
+            WHERE p.status = \'active\'
+            ORDER BY elo DESC, p.username ASC LIMIT 10;
+        ', Player::getEagerColumns('p'));
+        $results = $db->query($seasonQuery, [$term, $year]);
+        $players = Player::createFromDatabaseResults($results);
+
+        return [
+            'season'  => ucfirst($term),
+            'year'    => $year,
+            'players' => $players,
+        ];
+    }
+
+    private function parseSeason($string, &$term, &$year)
+    {
+        $string = strtolower($string);
+        $currentSeason = ($string === 'current');
+
+        if (!$currentSeason) {
+            $seasonTerm = explode('-', $string);
+
+            if ($this->validSeason($seasonTerm)) {
+                $term = $seasonTerm[0];
+                $year = (int)$seasonTerm[1];
+
+                return;
+            }
+        }
+
+        $term = Season::getCurrentSeason();
+        $year = TimeDate::now()->year;
+
+        return;
+    }
+
+    private function validSeason($seasonSplit)
+    {
+        if (empty($seasonSplit) || count($seasonSplit) != 2) {
+            return false;
+        }
+
+        if (in_array($seasonSplit[0], [Season::WINTER, Season::SPRING, Season::SUMMER, Season::FALL])) {
+            $currentYear = TimeDate::now()->year;
+            $seasonYear = (int)$seasonSplit[1];
+
+            // The season's in the future
+            if ($seasonYear > $currentYear) {
+                return false;
+            }
+
+            // If the year's the same, we need to make sure the season's not in the future; e.g. Fall 2017 shouldn't be
+            // valid when it's only July 2017
+            if ($seasonYear == $currentYear &&
+                Season::toInt($seasonSplit[0]) > Season::toInt(Season::getCurrentSeason())
+            ) {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/models/Player.php
+++ b/models/Player.php
@@ -191,11 +191,11 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
         $this->avatar = $player['avatar'];
         $this->country = $player['country'];
 
-        if (key_exists('activity', $player)) {
+        if (array_key_exists('activity', $player)) {
             $this->matchActivity = ($player['activity'] != null) ? $player['activity'] : 0.0;
         }
 
-        if (key_exists('elo', $player)) {
+        if (array_key_exists('elo', $player)) {
             $this->elo = $player['elo'];
         }
     }

--- a/models/Player.php
+++ b/models/Player.php
@@ -152,6 +152,13 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
      */
     private $cachedMatchCount = null;
 
+    /**
+     * The Elo for this player that has been explicitly set for this player from a database query. This value will take
+     * precedence over having to build to an Elo season history.
+     *
+     * @var int
+     */
+    private $elo;
     private $eloSeason;
     private $eloSeasonHistory;
 
@@ -186,6 +193,10 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
 
         if (key_exists('activity', $player)) {
             $this->matchActivity = ($player['activity'] != null) ? $player['activity'] : 0.0;
+        }
+
+        if (key_exists('elo', $player)) {
+            $this->elo = $player['elo'];
         }
     }
 
@@ -422,6 +433,11 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
      */
     public function getElo($season = null, $year = null)
     {
+        // The Elo for this player has been forcefully set from a trusted database query, so just return that.
+        if ($this->elo !== null) {
+            return $this->elo;
+        }
+
         $this->getEloSeasonHistory($season, $year);
         $seasonKey = $this->buildSeasonKey($season, $year);
 

--- a/src/QueryBuilder/QueryBuilder.php
+++ b/src/QueryBuilder/QueryBuilder.php
@@ -329,18 +329,6 @@ class QueryBuilder implements Countable
     }
 
     /**
-     * Request that a timestamp is between a date range
-     *
-     * @param MonthDateRange $range
-     * @param int|null       $year
-     */
-    public function betweenMonths(MonthDateRange $range, $year = null)
-    {
-        $this->isAfter($range->getStartOfRange($year), true);
-        $this->isBefore($range->getEndOfRange($year), true);
-    }
-
-    /**
      * Request that a column equals a number
      *
      * @param  int|Model|null $number The number that the column's value should

--- a/src/Season.php
+++ b/src/Season.php
@@ -9,6 +9,26 @@ abstract class Season
     const SUMMER = 'summer';
     const FALL = 'fall';
 
+    public static function toInt($season)
+    {
+        switch ($season) {
+            case self::WINTER:
+                return 1;
+
+            case self::SPRING:
+                return 2;
+
+            case self::SUMMER:
+                return 3;
+
+            case self::FALL:
+                return 4;
+
+            default:
+                return -1;
+        }
+    }
+
     public static function getSeason(DateTime $dateTime)
     {
         return [

--- a/views/Season/show.html.twig
+++ b/views/Season/show.html.twig
@@ -1,0 +1,43 @@
+{% extends 'layout.html.twig' %}
+
+{% block pageTitle %}
+    <h1>{{ season }} {{ year }} Season</h1>
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-6"></div>
+            <div class="col-md-6">
+                <h2>Season Leaderboard</h2>
+
+                <table>
+                    <caption></caption>
+                    <thead>
+                        <tr>
+                            <th>Position</th>
+                            <th>Player</th>
+                            <th>Elo</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% set lastElo = 9999 %}
+                        {% set pos = 0 %}
+
+                        {% for player in players %}
+                            {% if player.elo < lastElo %}
+                                {% set pos = pos + 1 %}
+                                {% set lastElo = player.elo %}
+                            {% endif %}
+                            <tr>
+                                <td>{{ pos }}</td>
+                                <td>{{ link_to(player) }}</td>
+                                <td>{{ player.elo }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/views/Season/show.html.twig
+++ b/views/Season/show.html.twig
@@ -6,13 +6,62 @@
 
 {% block content %}
     <div class="container">
+        <section class="mb3">
+            <h2>Season Matches</h2>
+            <p>What type of matches have occurred this season and how many of each?</p>
+
+            <div class="row text-center">
+                <div class="col-sm-6">
+                    <p class="mb0 t4 t5-sm">
+                        <strong>{{ offiCount | number_abbr(noun='official match', content='have taken place this season') }}</strong>
+                    </p>
+                    <p>{{ 'Official Match' | plural(offiCount, hideNumber=true) }}</p>
+                </div>
+                <div class="col-sm-6">
+                    <p class="mb0 t4 t5-sm">
+                        <strong>{{ fmCount | number_abbr(noun='fun match', content='have taken place this season') }}</strong>
+                    </p>
+                    <p>{{ 'Fun Match' | plural(fmCount, hideNumber=true) }}</p>
+                </div>
+            </div>
+        </section>
+
         <div class="row">
-            <div class="col-md-6"></div>
+            <div class="col-md-6">
+                <h2>Favorite Season Maps</h2>
+                <p>Which map is your favorite and is it on the list? If not, go gather players and play some matches on those maps!</p>
+
+                <table>
+                    <caption>A list containing the amount of matches that have occurred on each map. Not all matches may have maps reported. Only maps which have had at least one match played this season are listed.</caption>
+                    <thead>
+                    <tr>
+                        <th>Map Name</th>
+                        <th>Match Count</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for map in maps %}
+                        <tr>
+                            <td>
+                                {{ link_to(map) }}
+                            </td>
+                            <td>{{ mapCount[map.id]['match_count'] }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
             <div class="col-md-6">
                 <h2>Season Leaderboard</h2>
 
+                <p>How do you rank amongst the leaders of this season? Got what it takes to climb up to the top? Put your money where your Elo is.</p>
+
                 <table>
-                    <caption></caption>
+                    <caption>
+                        The leaders of this season sorted by highest Elo; for any ties in Elo, they are sorted in
+                        alphabetical order by callsign. Only the top ten players will be listed regardless of ties for
+                        the last spots.
+                    </caption>
                     <thead>
                         <tr>
                             <th>Position</th>
@@ -30,7 +79,7 @@
                                 {% set lastElo = player.elo %}
                             {% endif %}
                             <tr>
-                                <td>{{ pos }}</td>
+                                <td>{{ pos }}.</td>
                                 <td>{{ link_to(player) }}</td>
                                 <td>{{ player.elo }}</td>
                             </tr>

--- a/views/Season/show.html.twig
+++ b/views/Season/show.html.twig
@@ -27,7 +27,7 @@
         </section>
 
         <div class="row">
-            <div class="col-md-6">
+            <div class="col-md-6 mb3">
                 <h2>Favorite Season Maps</h2>
                 <p>Which map is your favorite and is it on the list? If not, go gather players and play some matches on those maps!</p>
 
@@ -51,7 +51,7 @@
                     </tbody>
                 </table>
             </div>
-            <div class="col-md-6">
+            <div class="col-md-6 mb3">
                 <h2>Season Leaderboard</h2>
 
                 <p>How do you rank amongst the leaders of this season? Got what it takes to climb up to the top? Put your money where your Elo is.</p>
@@ -84,6 +84,68 @@
                                 <td>{{ player.elo }}</td>
                             </tr>
                         {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+
+            {% macro match_count_table(match_type, match_array) %}
+                {% set lastCount = 9999 %}
+                {% set pos = 0 %}
+
+                {% for index, player in match_array[match_type].players %}
+                    {% if match_array[match_type].count[index] < lastCount %}
+                        {% set pos = pos + 1 %}
+                        {% set lastCount = match_array[match_type].count[index] %}
+                    {% endif %}
+                    <tr>
+                        <td>{{ pos }}.</td>
+                        <td>{{ link_to(player) }}</td>
+                        <td>{{ match_array[match_type].count[index] }}</td>
+                    </tr>
+                {% endfor %}
+            {% endmacro %}
+
+            <div class="col-md-6 mb3 mb0-md">
+                <h2>Most Active FMers</h2>
+                <p>Who doesn't love a good old fun match? Well, these players certainly love them.</p>
+
+                <table>
+                    <caption>
+                        The players who have participated in the most fun matches for this season sorted in descending
+                        order based on match count. Only the top ten players will be listed regardless of ties for
+                        the last spots.
+                    </caption>
+                    <thead>
+                        <tr>
+                            <th>Position</th>
+                            <th>Player</th>
+                            <th>Match Count</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{ _self.match_count_table('fm', player_matches) }}
+                    </tbody>
+                </table>
+            </div>
+            <div class="col-md-6">
+                <h2>Most Active Offi Matchers</h2>
+                <p>If you're in it for the Elo, these are the players to compete against.</p>
+
+                <table>
+                    <caption>
+                        The players who have participated in the most official matches for this season sorted in
+                        descending order based on match count. Only the top ten players will be listed regardless of
+                        ties for the last spots.
+                    </caption>
+                    <thead>
+                    <tr>
+                        <th>Position</th>
+                        <th>Player</th>
+                        <th>Match Count</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                        {{ _self.match_count_table('official', player_matches) }}
                     </tbody>
                 </table>
             </div>

--- a/views/navbar.html.twig
+++ b/views/navbar.html.twig
@@ -38,6 +38,7 @@
         {{ _self.page('Teams', 'Team', 'team_list', 'users') }}
         {{ _self.page('Players', 'Player', 'player_list', 'user') }}
         {{ _self.page('Matches', 'Match', 'match_list', 'trophy') }}
+        {{ _self.page('Season', 'Season', 'season_show', 'calendar') }}
 
         {% if me is valid %}
             <li class="u-show u-hide-sm">


### PR DESCRIPTION
With the introduction of seasons, it's become necessary to have a page dedicated to statistics for the given season.

- [x] Created new route for Seasons + validation for existing seasons
- [x] Player model now supports explicit Elo values being set from database results
- [x] Season page link added to navigation bar
- [x] Add match stats in the current season
  - [x] Amount of FMs
  - [x] Amount of Officials
  - [x] Favorite map
- [x] Display players with most matches in the season
- [ ] ~~Display players with most wins in the season~~
  - disregarding for now due to laziness. We'd need some more queries for counting FM wins and Official wins.

Closes #158 