### PR TITLE
Optimize `matches` table

### DIFF
--- a/migrations/20171228032336_matches_table_restructure.php
+++ b/migrations/20171228032336_matches_table_restructure.php
@@ -1,0 +1,147 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class MatchesTableRestructure extends AbstractMigration
+{
+    //
+    // This table will be used to store participation of players in matches. This is to take the place of a comma
+    // separated column in the `matches` table for faster JOIN operations versus string operations.
+    //
+
+    public function up()
+    {
+        $playerParticipationTable = $this->table('match_participation', [
+            'id' => false,
+            'primary_key' => ['match_id', 'user_id']
+        ]);
+        $playerParticipationTable
+            ->addColumn('match_id', 'integer', [
+                'signed' => false,
+                'limit' => 10,
+                'null' => false,
+                'comment' => 'The ID of the match this player participated in',
+            ])
+            ->addColumn('user_id', 'integer', [
+                'signed' => false,
+                'limit' => 10,
+                'null' => false,
+                'comment' => 'The ID of the player who participated in this match',
+            ])
+            ->addColumn('team_id', 'integer', [
+                'signed' => false,
+                'limit' => 10,
+                'null' => true,
+                'comment' => 'The ID of the team this player played for at the time of this match'
+            ])
+            ->addColumn('callsign', 'string', [
+                'null' => true,
+                'comment' => 'The callsign used by the player during this match.',
+            ])
+            ->addColumn('ip_address', 'string', [
+                'limit' => 46,
+                'null' => true,
+                'comment' => 'The IP address used by the player in this match',
+            ])
+            // Integer operations in SQL are faster than strings; so for team loyalty, we can simplify it to 0 or 1
+            ->addColumn('team_loyalty', 'integer', [
+                'after' => 'callsign',
+                'limit' => 1,
+                'null' => false,
+                'comment' => 'The team color this player played for: 0 will be for "TEAM A" and 1 will be for "TEAM B"'
+            ])
+            ->addForeignKey('match_id', 'matches', 'id', ['delete' => 'CASCADE'])
+            ->addForeignKey('user_id', 'players', 'id', ['delete' => 'CASCADE'])
+            ->addForeignKey('team_id', 'teams', 'id', ['delete' => 'SET_NULL'])
+            ->create()
+        ;
+
+        $statement = $this->query("SELECT * FROM matches WHERE (team_a_players IS NOT NULL AND team_a_players != '') OR (team_b_players IS NOT NULL AND team_b_players != '')");
+        $matches = $statement->fetchAll();
+        $insertData = [];
+
+        foreach ($matches as $match) {
+            $team_a_players = explode(',', $match['team_a_players']);
+            $team_b_players = explode(',', $match['team_b_players']);
+
+            $dataBuilder = function(array $playerIDs, $isTeamB) use (&$insertData, $match) {
+                foreach ($playerIDs as $playerID) {
+                    if (empty($playerID)) {
+                        continue;
+                    }
+
+                    $workspace = [
+                        'match_id' => $match['id'],
+                        'user_id' => $playerID,
+                        'team_loyalty' => (int)$isTeamB,
+                    ];
+
+                    if ($match['team_a'] !== null && !$isTeamB) {
+                        $workspace['team_id'] = $match['team_a'];
+                    } elseif ($match['team_b'] !== null && $isTeamB) {
+                        $workspace['team_id'] = $match['team_b'];
+                    }
+
+                    $insertData[] = $workspace;
+                }
+            };
+
+            $dataBuilder($team_a_players, false);
+            $dataBuilder($team_b_players, true);
+        }
+
+        // Only attempt to insert data if we actually have data to insert, otherwise an exception will be thrown
+        if (!empty($insertData)) {
+            $playerParticipationTable->insert($insertData);
+            $playerParticipationTable->saveData();
+        }
+
+        $matchesTable = $this->table('matches');
+        $matchesTable
+            ->removeColumn('team_a_players')
+            ->removeColumn('team_b_players')
+            ->update()
+        ;
+    }
+
+    public function down()
+    {
+        $matchesTable = $this->table('matches');
+        $matchesTable
+            ->addColumn('team_a_players', 'string', [
+                'after' => 'team_b_points',
+                'limit' => 256,
+                'null' => true,
+                'comment' => 'A comma-separated list of BZIDs of players who where on Team 1'
+            ])
+            ->addColumn('team_b_players', 'string', [
+                'after' => 'team_a_players',
+                'limit' => 256,
+                'null' => true,
+                'comment' => 'A comma-separated list of BZIDs of players who where on Team 2'
+            ])
+            ->update()
+        ;
+
+        $statement = $this->query('
+            SELECT
+              match_id, 
+              GROUP_CONCAT(IF(team_loyalty = 0, user_id, NULL)) AS team_a_players,
+              GROUP_CONCAT(IF(team_loyalty = 1, user_id, NULL)) AS team_b_players
+            FROM
+              match_participation
+            GROUP BY
+              match_id;
+        ');
+        $results = $statement->fetchAll();
+
+        foreach ($results as $result) {
+            $this->execute(sprintf("
+                UPDATE matches SET team_a_players = '%s', team_b_players = '%s' WHERE id = %d
+            ", $result['team_a_players'], $result['team_b_players'], $result['match_id']));
+        }
+
+        $playerParticipationTable = $this->table('match_participation');
+        $playerParticipationTable->drop();
+    }
+}

--- a/models/Match.php
+++ b/models/Match.php
@@ -460,13 +460,18 @@ class Match extends UrlModel implements NamedModel
     }
 
     /**
-     * Set the players of the match's teams
+     * Set the players of the match's teams.
      *
-     * @param int[] $teamAPlayers An array of player IDs
-     * @param int[] $teamBPlayers An array of player IDs
+     * @param int[]    $a_players   An array of player IDs on Team A
+     * @param int[]    $b_players   An array of player IDs on Team B
+     * @param string[] $a_ips       The IPs used by players on Team A. The order MUST match the order of $teamAPlayers
+     * @param string[] $b_ips       The IPs used by players on Team B. The order MUST match the order of $teamBPlayers
+     * @param string[] $a_callsigns The callsigns used by players on Team A. The order MUST match the order of $teamAPlayers
+     * @param string[] $b_callsigns The callsigns used by players on Team B. The order MUST match the order of $teamBPlayers
+     *
      * @return self
      */
-    public function setTeamPlayers($teamAPlayers = [], $teamBPlayers = [], $teamAIPs = [], $teamBIPs = [], $teamACallsigns = [], $teamBCallsigns = [])
+    public function setTeamPlayers($a_players = [], $b_players = [], $a_ips = [], $b_ips = [], $a_callsigns = [], $b_callsigns = [])
     {
         $this->db->execute('DELETE FROM match_participation WHERE match_id = ?', [
             $this->getId(),
@@ -478,17 +483,17 @@ class Match extends UrlModel implements NamedModel
             $matchParticipation,
             ($this->getTeamA() instanceof Team) ? $this->team_a : null,
             0,
-            $teamAPlayers,
-            $teamAIPs,
-            $teamACallsigns
+            $a_players,
+            $a_ips,
+            $a_callsigns
         );
         $this->matchParticipationEntryBuilder(
             $matchParticipation,
             ($this->getTeamB() instanceof Team) ? $this->team_b : null,
             1,
-            $teamBPlayers,
-            $teamBIPs,
-            $teamBCallsigns
+            $b_players,
+            $b_ips,
+            $b_callsigns
         );
 
         $this->db->insertBatch('match_participation', $matchParticipation);

--- a/src/Model/BaseModel.php
+++ b/src/Model/BaseModel.php
@@ -446,29 +446,9 @@ abstract class BaseModel implements ModelInterface
     {
         $table = (empty($table)) ? static::TABLE : $table;
         $db = Database::getInstance();
+        $id = $db->insert($table, $params, $now);
 
-        $columns = implode('`,`', array_keys($params));
-        $columns = "`$columns`";
-
-        $question_marks = str_repeat('?,', count($params));
-        $question_marks = rtrim($question_marks, ','); // Remove last comma
-
-        if ($now) {
-            if (!is_array($now)) {
-                // Convert $now to an array if it's a string
-                $now = array($now);
-            }
-
-            foreach ($now as $column) {
-                $columns .= ",$column";
-                $question_marks .= ",UTC_TIMESTAMP()";
-            }
-        }
-
-        $query = "INSERT into $table ($columns) VALUES ($question_marks)";
-        $db->execute($query, array_values($params));
-
-        return static::get($db->getInsertId());
+        return static::get($id);
     }
 
     /**

--- a/tests/ModelTests/MatchTest.php
+++ b/tests/ModelTests/MatchTest.php
@@ -590,6 +590,56 @@ class MatchTest extends TestCase
         $this->assertEquals(1200 - $playerEloDiff, $this->player_b->getElo());
     }
 
+    public function testPlayerMatchParticipationIsRecorded()
+    {
+        $player_c = $this->getNewPlayer();
+        $player_d = $this->getNewPlayer();
+
+        $player_a_ip = '127.0.0.1';
+        $player_b_ip = '127.0.0.2';
+        $player_c_ip = '127.0.0.3';
+        $player_d_ip = '127.0.0.4';
+
+        $this->match = Match::enterMatch(
+            null,
+            null,
+            0,
+            0,
+            30,
+            null,
+            'now',
+            [$this->player_a->getId(), $player_c->getId()],
+            [$this->player_b->getId(), $player_d->getId()],
+            null,
+            null,
+            null,
+            'official',
+            'red',
+            'purple',
+            [$player_a_ip, $player_c_ip],
+            [$player_b_ip, $player_d_ip],
+            [$this->player_a->getName(), $player_c->getName()],
+            [$this->player_b->getName(), $player_d->getName()]
+        );
+
+        $this->assertNotEmpty($this->match->getTeamAPlayers());
+        $this->assertNotEmpty($this->match->getTeamBPlayers());
+        $this->assertInstanceOf(Player::class, $this->match->getTeamAPlayers()[0]);
+        $this->assertInstanceOf(Player::class, $this->match->getTeamBPlayers()[0]);
+        $this->assertArrayContainsModel($this->player_a, $this->match->getTeamAPlayers());
+        $this->assertArrayContainsModel($this->player_b, $this->match->getTeamBPlayers());
+
+        $this->assertEquals($player_a_ip, $this->match->getPlayerIpAddress($this->player_a));
+        $this->assertEquals($player_b_ip, $this->match->getPlayerIpAddress($this->player_b));
+        $this->assertEquals($player_c_ip, $this->match->getPlayerIpAddress($player_c));
+        $this->assertEquals($player_d_ip, $this->match->getPlayerIpAddress($player_d));
+
+        $this->assertEquals($this->player_a->getName(), $this->match->getPlayerCallsign($this->player_a));
+        $this->assertEquals($this->player_b->getName(), $this->match->getPlayerCallsign($this->player_b));
+        $this->assertEquals($player_c->getName(), $this->match->getPlayerCallsign($player_c));
+        $this->assertEquals($player_d->getName(), $this->match->getPlayerCallsign($player_d));
+    }
+
     public function tearDown()
     {
         $this->wipe($this->match, $this->match_b, $this->team_a, $this->team_b);


### PR DESCRIPTION
The `matches` table has had its `team_a_players` and `team_b_players` columns dropped and that data moved to a separate table. Integer operations are far faster than string operations. This change will also allow for better JOIN queries in the future to better display statistics.

- [x] Update `Match::setTeamPlayers()` to work with the new structure
- [x] Add support for newly tracked IP and callsign data to the LeagueOverseer endpoint

closes #152 