### PR TITLE
Fix bug in Elo recalculations

### DIFF
--- a/app/Resource/symfony.yml
+++ b/app/Resource/symfony.yml
@@ -126,6 +126,10 @@ services:
         class: BZIon\Command\SuccessCommand
         tags:
             - { name: console.command }
+    bzion.command.recalc_elo_command:
+        class: BZIon\Command\RecalculateEloCommand
+        tags:
+            - { name: console.command }
     bzion.listener.maintenance:
         class: BZIon\Event\MaintenanceListener
         arguments: [%bzion.miscellaneous.maintenance%]

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "jdorn/sql-formatter": "~1.2",
         "phpunit/phpunit": "~5.7",
         "sensio/distribution-bundle": "~3.0",
-        "sensiolabs/security-checker": "~4.1"
+        "sensiolabs/security-checker": "~4.1",
+        "fzaninotto/faker": "^1.7"
     },
 
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccbd7893f191a0d688246aeefb4b2878",
+    "content-hash": "78f0dbb1698ae49c4c937975df0c3933",
     "packages": [
         {
             "name": "cboden/ratchet",
@@ -3703,6 +3703,56 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.0 || ^5.0",
+                "squizlabs/php_codesniffer": "^1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2017-08-15T16:48:10+00:00"
         },
         {
             "name": "jdorn/sql-formatter",

--- a/controllers/MatchController.php
+++ b/controllers/MatchController.php
@@ -140,7 +140,24 @@ class MatchController extends CRUDController
             $response = new StreamedResponse();
             $response->headers->set('Content-Type', 'text/plain');
             $response->setCallback(function () use ($match) {
-                $this->log(Match::recalculateMatchesSince($match));
+                $this->log(Match::recalculateMatchesSince($match, function ($event) {
+                    switch ($event['type']) {
+                        case 'recalculation.count':
+                            echo $event['type'] . "\n";
+                            break;
+
+                        case 'recalculation.progress':
+                            echo 'm';
+                            break;
+
+                        case 'recalculation.complete':
+                            echo "\n\nCalculation successful\n";
+                            break;
+
+                        default:
+                            break;
+                    }
+                }));
             });
             $response->send();
         }, "Do you want to recalculate ELO history for all teams and matches after the specified match?",

--- a/models/Match.php
+++ b/models/Match.php
@@ -1359,7 +1359,7 @@ class Match extends UrlModel implements NamedModel
      *
      * @throws Exception
      */
-    public static function recalculateMatchesSince(Match $match)
+    public static function recalculateMatchesSince(Match $match, callable $callable = null)
     {
         try {
             // Commented out to prevent ridiculously large recalculations
@@ -1374,8 +1374,13 @@ class Match extends UrlModel implements NamedModel
             /** @var Match[] $matches */
             $matches = $query->getModels($fast = true);
 
-            // Send the total count to client-side javascript
-            echo count($matches) . "\n";
+            // Send the total count to whoever is listening
+            if ($callable !== null) {
+                $callable([
+                    'type'  => 'recalculation.count',
+                    'value' => count($matches),
+                ]);
+            }
 
             // Start a transaction so tables are locked and we don't stay with
             // messed up data if something goes wrong
@@ -1407,9 +1412,13 @@ class Match extends UrlModel implements NamedModel
 
                 $match->recalculateElo();
 
-                // Send an update to the client-side javascript, so that a
-                // progress bar can be updated
-                echo "m";
+                // Send an update that a match has been recalculated
+                if ($callable !== null) {
+                    $callable([
+                        'type'  => 'recalculation.progress',
+                        'value' => $match->getId(),
+                    ]);
+                }
             }
         } catch (Exception $e) {
             Database::getInstance()->rollback();
@@ -1419,7 +1428,13 @@ class Match extends UrlModel implements NamedModel
 
         Database::getInstance()->finishTransaction();
 
-        echo "\n\nCalculation successful\n";
+        // Send an update that all of the calculations have finished
+        if ($callable !== null) {
+            $callable([
+                'type'  => 'recalculation.complete',
+                'value' => true,
+            ]);
+        }
     }
 
     /**

--- a/models/Match.php
+++ b/models/Match.php
@@ -1222,11 +1222,11 @@ class Match extends UrlModel implements NamedModel
      */
     public function resetPlayerElos()
     {
-        $this->db->execute('DELETE FROM player_elo WHERE match_id = ?', [$this->getId()]);
-
         foreach ($this->getPlayers() as $player) {
             $player->invalidateMatchFromCache($this);
         }
+
+        $this->db->execute('DELETE FROM player_elo WHERE match_id = ?', [$this->getId()]);
     }
 
     /**

--- a/models/Match.php
+++ b/models/Match.php
@@ -1223,6 +1223,10 @@ class Match extends UrlModel implements NamedModel
     public function resetPlayerElos()
     {
         $this->db->execute('DELETE FROM player_elo WHERE match_id = ?', [$this->getId()]);
+
+        foreach ($this->getPlayers() as $player) {
+            $player->invalidateMatchFromCache($this);
+        }
     }
 
     /**
@@ -1238,10 +1242,6 @@ class Match extends UrlModel implements NamedModel
         $b = $this->getTeamB();
 
         $this->resetPlayerElos();
-
-        foreach ($this->getPlayers() as $player) {
-            $player->invalidateMatchFromCache($this);
-        }
 
         $eloCalcs = self::calculateElos(
             $a, $b,
@@ -1302,6 +1302,7 @@ class Match extends UrlModel implements NamedModel
      */
     public function delete()
     {
+        $this->resetPlayerElos();
         $this->updateMatchCount(true);
 
         parent::delete();

--- a/models/Player.php
+++ b/models/Player.php
@@ -360,6 +360,8 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
         $seasonKey = $this->buildSeasonKeyFromTimestamp($match->getTimestamp());
         $seasonElo = null;
 
+        $this->getEloSeasonHistory();
+
         if (!isset($this->eloSeasonHistory[$seasonKey][$match->getId()])) {
             return;
         }
@@ -388,7 +390,7 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
             return $this->eloSeasonHistory[$seasonKey];
         }
 
-        $this->eloSeasonHistory[$seasonKey] = $this->db->query('
+        $result = $this->db->query('
           SELECT
             elo_new AS elo,
             match_id AS `match`,
@@ -404,13 +406,13 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
             match_id ASC
         ', [ $this->getId(), $season, $year ]);
 
-        array_unshift($this->eloSeasonHistory[$seasonKey], [
+        $this->eloSeasonHistory[$seasonKey] = [[
             'elo' => 1200,
             'match' => null,
             'month' => Season::getCurrentSeasonRange($season)->getStartOfRange()->month,
             'year' => $year,
             'day' => 1
-        ]);
+        ]] + array_combine(array_column($result, 'match'), $result);
 
         return $this->eloSeasonHistory[$seasonKey];
     }

--- a/models/Player.php
+++ b/models/Player.php
@@ -357,10 +357,11 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
      */
     public function invalidateMatchFromCache(Match $match)
     {
+        $seasonInfo = Season::getSeason($match->getTimestamp());
         $seasonKey = $this->buildSeasonKeyFromTimestamp($match->getTimestamp());
         $seasonElo = null;
 
-        $this->getEloSeasonHistory();
+        $this->getEloSeasonHistory($seasonInfo['season'], $seasonInfo['year']);
 
         if (!isset($this->eloSeasonHistory[$seasonKey][$match->getId()])) {
             return;

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -5,7 +5,7 @@ namespace BZIon\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 class Command extends ContainerAwareCommand
@@ -14,8 +14,8 @@ class Command extends ContainerAwareCommand
 
     /**
      * Initialise the progress bar
-     * @param  Output $output The output
-     * @param  int    $count  The number of steps
+     * @param  OutputInterface $output The output
+     * @param  int             $count  The number of steps
      * @return void
      */
     protected function initProgress($output, $count)
@@ -69,7 +69,7 @@ class Command extends ContainerAwareCommand
      * Return a function that can be used by Symfony's process to show the output
      * of a process live on our screen
      *
-     * @param  Output $output The console output
+     * @param  OutputInterface $output The console output
      *
      * @return null|\Closure
      */

--- a/src/Command/RecalculateEloCommand.php
+++ b/src/Command/RecalculateEloCommand.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This symfony command will recalculate Elo matches
+ *
+ * @package    BZiON
+ * @license    https://github.com/allejo/bzion/blob/master/LICENSE.md GNU General Public License Version 3
+ */
+
+namespace BZIon\Command;
+
+use Match;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RecalculateEloCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('bzion:recalc-elo')
+            ->setDescription('Recalculate Elos for a given match and all of the matches proceeding it.')
+            ->addArgument('matchID', InputArgument::REQUIRED, 'The ID of the first match that needs to be recalculated.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $id = $input->getArgument('matchID');
+        $match = Match::get($id);
+
+        if (!$match->isValid()) {
+            $output->writeln(sprintf('No match found with id: %d', $id));
+            exit(1);
+        }
+
+        $output->writeln(sprintf('Starting Elo recalculation with match #%d...', $id));
+        $output->writeln(sprintf('  (this may take a while)'));
+
+        try {
+            Match::recalculateMatchesSince($match, function ($event) use ($output) {
+                switch ($event['type']) {
+                    case 'recalculation.count':
+                        $output->writeln(sprintf("\nDetected %d matches needing recalculations\n", $event['value']));
+                        $this->initProgress($output, $event['value']);
+                        break;
+
+                    case 'recalculation.progress':
+                        $this->advance();
+                        break;
+
+                    case 'recalculation.complete':
+                        $this->finishProgress();
+                        break;
+
+                    default:
+                        $output->writeln(sprintf('Received unknown recalculation event: %s', $event['type']));
+                }
+            });
+        }
+        catch (\Exception $e) {
+            $errMsg = $e->getMessage();
+
+            $output->writeln(<<<EXCEPTION
+            
+<bg=red;options=bold>
+ [ERROR] An exception occurred with the following message:
+   ${$errMsg}
+</>
+EXCEPTION
+);
+            exit(1);
+        }
+
+        $output->writeln(<<<SUCCESS
+
+<bg=green;options=bold>
+
+ [OK] Match Elos have been successfully recalculated.
+</>
+SUCCESS
+        );
+    }
+}

--- a/tests/ModelTests/MatchEloTest.php
+++ b/tests/ModelTests/MatchEloTest.php
@@ -2,6 +2,10 @@
 
 class MatchEloTest extends TestCase
 {
+    const TEAM_LOSS = 0;
+    const TEAM_WIN = 1;
+    const TEAM_DRAW = 2;
+
     /** @var \Faker\Generator */
     private $faker;
     private $createdModels = [];
@@ -23,8 +27,11 @@ class MatchEloTest extends TestCase
         parent::tearDown();
     }
 
-    // Yes, we need a test for our own helper function in our tests
-    public function testGenerateMatches()
+    //
+    // Yes, we need to test our own helper function in our tests
+    //
+
+    public function testGenerateMatchesWithNoRiggedMatches()
     {
         $matchCount = 8;
 
@@ -36,6 +43,48 @@ class MatchEloTest extends TestCase
         $this->assertArrayLengthEquals($matches, $matchCount);
         $this->assertInstanceOf(Team::class, $team);
         $this->assertInstanceOf(Match::class, $matches[0]);
+    }
+
+    public function testGenerateMatchesWithRiggedWin()
+    {
+        /**
+         * @var Match[] $matches
+         */
+        $team = null;
+        $matches = [];
+        $riggedMatch = 3;
+
+        $this->generateMatches(5, $team, $matches, $riggedMatch, self::TEAM_WIN);
+
+        $this->assertGreaterThan($matches[$riggedMatch]->getTeamBPoints(), $matches[$riggedMatch]->getTeamAPoints());
+    }
+
+    public function testGenerateMatchesWithRiggedLoss()
+    {
+        /**
+         * @var Match[] $matches
+         */
+        $team = null;
+        $matches = [];
+        $riggedMatch = 2;
+
+        $this->generateMatches(5, $team, $matches, $riggedMatch, self::TEAM_LOSS);
+
+        $this->assertGreaterThan($matches[$riggedMatch]->getTeamAPoints(), $matches[$riggedMatch]->getTeamBPoints());
+    }
+
+    public function testGenerateMatchesWithRiggedDraw()
+    {
+        /**
+         * @var Match[] $matches
+         */
+        $team = null;
+        $matches = [];
+        $riggedMatch = 4;
+
+        $this->generateMatches(5, $team, $matches, $riggedMatch, self::TEAM_DRAW);
+
+        $this->assertEquals($matches[$riggedMatch]->getTeamBPoints(), $matches[$riggedMatch]->getTeamAPoints());
     }
 
     public function testGenerateTeamWithPlayers()
@@ -52,76 +101,143 @@ class MatchEloTest extends TestCase
         $this->assertInstanceOf(Player::class, $players[0]);
     }
 
+    //
     // Onward to our real tests for Elo recalculations!
-    public function testEloRecalculation()
+    //
+
+    public static function eloRecalculationsProvider()
     {
-        /** @var Team $team */
+        return [
+            [ self::TEAM_DRAW, 'assertEquals' ],
+            [ self::TEAM_WIN,  'assertLessThan' ],
+            [ self::TEAM_LOSS, 'assertGreaterThan' ],
+        ];
+    }
+
+    /**
+     * @dataProvider eloRecalculationsProvider
+     *
+     * @param int    $riggedResult
+     * @param string $functionCall
+     *
+     * @see MatchEloTest::TEAM_LOSS
+     * @see MatchEloTest::TEAM_WIN
+     * @see MatchEloTest::TEAM_DRAW
+     *
+     * @throws Exception
+     */
+    public function testEloRecalculationOnSituation($riggedResult, $functionCall)
+    {
+        /**
+         * @var Team $team
+         * @var Match[] $matches
+         */
         $team = null;
-        /** @var Match[] $matches */
         $matches = [];
+        $riggedID = $this->faker->numberBetween(0, 9);
 
-        $this->generateMatches(10, $team, $matches);
+        $this->generateMatches(10, $team, $matches, $riggedID, $riggedResult);
 
-        $preRecalcTeamElo = $team->getElo();
-        $preRecalcLeaderElo = $team->getLeader()->getElo();
+        // The match we'll be editing in this recalculation test
+        $matchToEdit = $matches[$riggedID];
 
-        $matchToEdit = $matches[3];
+        // We need a random participant within the match to confirm that a player's Elo get updated
+        $matchParticipant = $matchToEdit->getPlayers($team)[0];
 
+        // Get values for the Match prior to edits being made
+        $preRecalcTeamElo = $matchToEdit->getTeamAEloNew();
+        $preRecalcPlayerEloBefore = $matchToEdit->getPlayerEloBefore($matchParticipant);
+        $preRecalcPlayerEloAfter  = $matchToEdit->getPlayerEloAfter($matchParticipant);
+        $preRecalcTeamEloDiff   = $matchToEdit->getEloDiff(false);
+        $preRecalcPlayerEloDiff = $matchToEdit->getPlayerEloDiff(false);
+
+        // Swap the team scores
         $scoreTeamA = $matchToEdit->getScore($matchToEdit->getTeamA());
         $scoreTeamB = $matchToEdit->getScore($matchToEdit->getTeamB());
-
         $matchToEdit->setTeamPoints($scoreTeamB, $scoreTeamA);
 
         ob_start();
         Match::recalculateMatchesSince($matchToEdit);
         ob_end_clean();
 
-        $newLeaderElo = Player::get($team->getLeader())->getElo();
-        $newTeamElo = Team::get($team->getId())->getElo();
+        // Forcefully get an updated object to bypass our cache
+        $matchRefreshed = Match::get($matchToEdit->getId());
 
-        $this->assertNotEquals($preRecalcLeaderElo, $newLeaderElo);
-        $this->assertNotEquals($preRecalcTeamElo, $newTeamElo);
+        // Get values for the Match *after* the edits have been made
+        $postRecalcTeamElo = $matchRefreshed->getTeamAEloNew();
+        $postRecalcPlayerEloBefore = $matchRefreshed->getPlayerEloBefore($matchParticipant);
+        $postRecalcPlayerEloAfter  = $matchRefreshed->getPlayerEloAfter($matchParticipant);
+        $postRecalcTeamEloDiff = $matchRefreshed->getEloDiff(false);
+        $postRecalcPlayerEloDiff = $matchRefreshed->getPlayerEloDiff(false);
+
+        // Recalculations don't touch matches prior to this, so the values should be identical
+        $this->assertEquals($preRecalcPlayerEloBefore, $postRecalcPlayerEloBefore);
+
+        // Custom Assertions
+        $this->{$functionCall}($preRecalcTeamElo,        $postRecalcTeamElo);
+        $this->{$functionCall}($preRecalcPlayerEloAfter, $postRecalcPlayerEloAfter);
+        $this->{$functionCall}($preRecalcTeamEloDiff,    $postRecalcTeamEloDiff);
+        $this->{$functionCall}($preRecalcPlayerEloDiff,  $postRecalcPlayerEloDiff);
     }
 
     /**
      * Generate random matches with a single team always being in the match.
      *
-     * @param int $numberOfMatches
-     * @param Team $team_a
+     * @param int     $numberOfMatches
+     * @param Team    $team_a
      * @param Match[] $matches
+     * @param int     $riggedMatchNumber
+     * @param int     $riggedResult
      *
      * @throws Exception
      */
-    private function generateMatches($numberOfMatches, &$team_a, array &$matches)
+    private function generateMatches($numberOfMatches, &$team_a, array &$matches, $riggedMatchNumber = -1, $riggedResult = self::TEAM_LOSS)
     {
-        $participantCount = $this->faker->numberBetween(2, 10);
-
         $team_a = $team_b = null;
         $team_a_players = $team_b_players = [];
+        $fullRosterCount = $this->faker->numberBetween(4, 15);
 
-        $this->generateTeamWithPlayers($participantCount, $team_a, $team_a_players);
-        $this->generateTeamWithPlayers($participantCount, $team_b, $team_b_players);
+        $this->generateTeamWithPlayers($fullRosterCount, $team_a, $team_a_players);
+        $this->generateTeamWithPlayers($fullRosterCount, $team_b, $team_b_players);
 
-        $team_a_roster = __::map($team_a_players, function ($n) { return $n->getId(); });
-        $team_b_roster = __::map($team_b_players, function ($n) { return $n->getId(); });
+        $participantCount = $this->faker->numberBetween(2, $fullRosterCount - 2);
 
         for ($i = 0; $i < $numberOfMatches; $i++) {
+            // Get only *some* of the players from each team to play in the matches
+            $team_a_roster = __::map($this->faker->randomElements($team_a_players, $participantCount), function ($n) { return $n->getId(); });
+            $team_b_roster = __::map($this->faker->randomElements($team_b_players, $participantCount), function ($n) { return $n->getId(); });
+
+            $team_a_score = $this->faker->numberBetween(0, 6);
+            $team_b_score = $this->faker->numberBetween(0, 6);
+
+            if ($riggedMatchNumber === $i) {
+                switch ($riggedResult) {
+                    case self::TEAM_LOSS:
+                        $team_a_score = 0;
+                        $team_b_score = $this->faker->numberBetween(1, 6);
+                        break;
+
+                    case self::TEAM_WIN:
+                        $team_a_score = $this->faker->numberBetween(1, 6);
+                        $team_b_score = 0;
+                        break;
+
+                    case self::TEAM_DRAW:
+                        $team_a_score = $team_b_score = $this->faker->numberBetween(1, 6);
+                        break;
+                }
+            }
+
             $matches[$i] = Match::enterMatch(
                 $team_a->getId(),
                 ($this->faker->boolean) ? $team_b : null,
-                $this->faker->numberBetween(0, 6),
-                $this->faker->numberBetween(0, 6),
+                $team_a_score,
+                $team_b_score,
                 $this->faker->randomElement([15, 20, 30]),
                 null,
                 sprintf('-%d days', $numberOfMatches - $i),
                 $team_a_roster,
-                $team_b_roster,
-                null,
-                null,
-                null,
-                'official',
-                'red',
-                'purple'
+                $team_b_roster
             );
 
             array_unshift($this->createdModels, $matches[$i]);

--- a/tests/ModelTests/MatchEloTest.php
+++ b/tests/ModelTests/MatchEloTest.php
@@ -1,0 +1,153 @@
+<?php
+
+class MatchEloTest extends TestCase
+{
+    /** @var \Faker\Generator */
+    private $faker;
+    private $createdModels = [];
+
+    protected function setUp()
+    {
+        $this->connectToDatabase();
+
+        $this->faker = Faker\Factory::create();
+    }
+
+    public function tearDown()
+    {
+        foreach ($this->createdModels as $model)
+        {
+            $this->wipe($model);
+        }
+
+        parent::tearDown();
+    }
+
+    // Yes, we need a test for our own helper function in our tests
+    public function testGenerateMatches()
+    {
+        $matchCount = 8;
+
+        $team = null;
+        $matches = [];
+
+        $this->generateMatches($matchCount, $team, $matches);
+
+        $this->assertArrayLengthEquals($matches, $matchCount);
+        $this->assertInstanceOf(Team::class, $team);
+        $this->assertInstanceOf(Match::class, $matches[0]);
+    }
+
+    public function testGenerateTeamWithPlayers()
+    {
+        $playerCount = 5;
+
+        $team = null;
+        $players = [];
+
+        $this->generateTeamWithPlayers($playerCount, $team, $players);
+
+        $this->assertArrayLengthEquals($players, $playerCount);
+        $this->assertInstanceOf(Team::class, $team);
+        $this->assertInstanceOf(Player::class, $players[0]);
+    }
+
+    // Onward to our real tests for Elo recalculations!
+    public function testEloRecalculation()
+    {
+        /** @var Team $team */
+        $team = null;
+        /** @var Match[] $matches */
+        $matches = [];
+
+        $this->generateMatches(10, $team, $matches);
+
+        $preRecalcTeamElo = $team->getElo();
+        $preRecalcLeaderElo = $team->getLeader()->getElo();
+
+        $matchToEdit = $matches[3];
+
+        $scoreTeamA = $matchToEdit->getScore($matchToEdit->getTeamA());
+        $scoreTeamB = $matchToEdit->getScore($matchToEdit->getTeamB());
+
+        $matchToEdit->setTeamPoints($scoreTeamB, $scoreTeamA);
+
+        ob_start();
+        Match::recalculateMatchesSince($matchToEdit);
+        ob_end_clean();
+
+        $newLeaderElo = Player::get($team->getLeader())->getElo();
+        $newTeamElo = Team::get($team->getId())->getElo();
+
+        $this->assertNotEquals($preRecalcLeaderElo, $newLeaderElo);
+        $this->assertNotEquals($preRecalcTeamElo, $newTeamElo);
+    }
+
+    /**
+     * Generate random matches with a single team always being in the match.
+     *
+     * @param int $numberOfMatches
+     * @param Team $team_a
+     * @param Match[] $matches
+     *
+     * @throws Exception
+     */
+    private function generateMatches($numberOfMatches, &$team_a, array &$matches)
+    {
+        $participantCount = $this->faker->numberBetween(2, 10);
+
+        $team_a = $team_b = null;
+        $team_a_players = $team_b_players = [];
+
+        $this->generateTeamWithPlayers($participantCount, $team_a, $team_a_players);
+        $this->generateTeamWithPlayers($participantCount, $team_b, $team_b_players);
+
+        $team_a_roster = __::map($team_a_players, function ($n) { return $n->getId(); });
+        $team_b_roster = __::map($team_b_players, function ($n) { return $n->getId(); });
+
+        for ($i = 0; $i < $numberOfMatches; $i++) {
+            $matches[$i] = Match::enterMatch(
+                $team_a->getId(),
+                ($this->faker->boolean) ? $team_b : null,
+                $this->faker->numberBetween(0, 6),
+                $this->faker->numberBetween(0, 6),
+                $this->faker->randomElement([15, 20, 30]),
+                null,
+                sprintf('-%d days', $numberOfMatches - $i),
+                $team_a_roster,
+                $team_b_roster,
+                null,
+                null,
+                null,
+                'official',
+                'red',
+                'purple'
+            );
+
+            array_unshift($this->createdModels, $matches[$i]);
+        }
+    }
+
+    /**
+     * Generate a real team with multiple players assigned to the team.
+     *
+     * @param int $playerCount
+     * @param Team $team
+     * @param Player[] $players
+     *
+     * @throws Exception
+     */
+    private function generateTeamWithPlayers($playerCount, &$team, array &$players)
+    {
+        $players[0] = $this->getNewPlayer();
+
+        $team = Team::createTeam($this->faker->text($maxNbChars = 42), $players[0]->getId(), '', '');
+
+        array_unshift($this->createdModels, $team);
+
+        for ($i = 1; $i < $playerCount; $i++) {
+            $players[$i] = $this->getNewPlayer();
+            $team->addMember($players[$i]->getId());
+        }
+    }
+}

--- a/tests/ModelTests/MatchTest.php
+++ b/tests/ModelTests/MatchTest.php
@@ -546,7 +546,7 @@ class MatchTest extends TestCase
             4,
             30,
             null,
-            'now',
+            '-1 day',
             [$this->player_a->getId(), $player_c->getId()],
             [$this->player_b->getId(), $player_d->getId()]
         );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,3 +4,7 @@ require_once dirname(__DIR__) . '/bzion-load.php';
 
 $kernel = new AppKernel('test', true);
 $kernel->boot();
+
+// @todo Extract clearDatabase() function to separate class
+// @body The test database should be cleared every time the bootstrap is run, therefore this functionality should be in a more generic context
+FeatureContext::clearDatabase();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,31 @@
 <?php
 
+use BZIon\Composer\ScriptHandler;
+
 require_once dirname(__DIR__) . '/bzion-load.php';
 
 $kernel = new AppKernel('test', true);
 $kernel->boot();
 
-// @todo Extract clearDatabase() function to separate class
-// @body The test database should be cleared every time the bootstrap is run, therefore this functionality should be in a more generic context
-FeatureContext::clearDatabase();
+function clearDatabase()
+{
+    $db = Database::getInstance();
+
+    // Get an array of the tables in the database, so that we can remove them
+    $tables = array_map(function ($val) { return current($val); },
+        $db->query('SHOW TABLES'));
+
+    if (count($tables) > 0) {
+        $db->execute('SET foreign_key_checks = 0');
+        $db->execute('DROP TABLES ' . implode($tables, ','));
+        $db->execute('SET foreign_key_checks = 1');
+    }
+
+    ScriptHandler::migrateDatabase(null, true);
+
+    if ($modelCache = Service::getModelCache()) {
+        $modelCache->clear();
+    }
+}
+
+clearDatabase();

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -43,7 +43,6 @@ class FeatureContext extends MinkContext implements SnippetAcceptingContext, Ker
      */
     public static function prepare($event)
     {
-        self::clearDatabase();
     }
 
     /**
@@ -327,29 +326,5 @@ class FeatureContext extends MinkContext implements SnippetAcceptingContext, Ker
     public function iAmAMemberOfATeamCalled($name)
     {
         $this->iHaveATeamCalled($name)->addMember($this->me->getId());
-    }
-
-    /**
-     * @Given that the database is empty
-     */
-    public static function clearDatabase()
-    {
-        $db = Database::getInstance();
-
-        // Get an array of the tables in the database, so that we can remove them
-        $tables = array_map(function ($val) { return current($val); },
-                            $db->query('SHOW TABLES'));
-
-        if (count($tables) > 0) {
-            $db->execute('SET foreign_key_checks = 0');
-            $db->execute('DROP TABLES ' . implode($tables, ','));
-            $db->execute('SET foreign_key_checks = 1');
-        }
-
-        ScriptHandler::migrateDatabase(null, true);
-
-        if ($modelCache = Service::getModelCache()) {
-            $modelCache->clear();
-        }
     }
 }


### PR DESCRIPTION
- Added "faker" as a dependency to generate random data in unit tests
- Matches delete player Elo changes from the database on delete and they
  delete the information from cached Player objects
- Players now cache their Elo changelog
- Always clear the database at the start of running unit tests
- Add unit test for Elo recalculation with random data

Closes #170