### PR TITLE
[WIP] Move to new QueryBuilder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 language: php
 php:
-  - 5.6
   - 7
   - 7.1
+  - 7.2
   - nightly
 
 matrix:
-  include:
-    - php: "hhvm"
-      env:
-        - NO_COVERAGE=1
-        - BZION_HHVM=1
   allow_failures:
-    - php: hhvm
     - php: nightly
   fast_finish: true
 

--- a/app/Resource/symfony_dev.yml
+++ b/app/Resource/symfony_dev.yml
@@ -5,8 +5,13 @@ services:
     bzion.command.log_command:
         class: BZIon\Command\LogCommand
         tags:
-
             -  { name: console.command }
+    bzion.twig_debug_extension:
+        class: Ajgl\Twig\Extension\BreakpointExtension
+        public: false
+        tags:
+            - { name: twig.extension }
+
 framework:
     router:
         resource: "%kernel.root_dir%/Resource/routes_dev.yml"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-only",
 
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0.9",
         "ext-PDO": "*",
         "ext-gd": "*",
         "ext-pdo_mysql": "*",
@@ -112,7 +112,7 @@
     },
     "config": {
         "platform": {
-            "php": "5.6.0"
+            "php": "7.0.9"
         },
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/swiftmailer-bundle": ">=2.3.0",
         "symfony/symfony": "~2.8",
         "twig/twig": "~1.18",
+        "usmanhalalit/pixie": "^2.0",
         "yzalis/identicon": "~1.2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "maciejczyzewski/bottomline": "dev-master",
         "nelmio/api-doc-bundle": "~2.7",
         "nesbot/carbon": "~1.14",
+        "pecee/pixie": "~4.2.5",
         "robmorgan/phinx": "~0.8",
         "sensio/framework-extra-bundle": "~3.0",
         "swiftmailer/swiftmailer": ">=5.2.0",
@@ -26,7 +27,6 @@
         "symfony/swiftmailer-bundle": ">=2.3.0",
         "symfony/symfony": "~2.8",
         "twig/twig": "~1.18",
-        "usmanhalalit/pixie": "^2.0",
         "yzalis/identicon": "~1.2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,17 +30,18 @@
         "yzalis/identicon": "~1.2.0"
     },
     "require-dev": {
+        "ajgl/breakpoint-twig-extension": "^0.3.1",
         "behat/behat": "~3.0",
         "behat/mink": "~1.6",
-        "behat/mink-extension": "~2.0",
         "behat/mink-browserkit-driver": "~1.2",
+        "behat/mink-extension": "~2.0",
         "behat/symfony2-extension": "~2.1.1",
         "composer/composer": "~1.5",
+        "fzaninotto/faker": "^1.7",
         "jdorn/sql-formatter": "~1.2",
         "phpunit/phpunit": "~5.7",
         "sensio/distribution-bundle": "~3.0",
-        "sensiolabs/security-checker": "~4.1",
-        "fzaninotto/faker": "^1.7"
+        "sensiolabs/security-checker": "~4.1"
     },
 
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3388c53d025e86953b9614b05bfc2b06",
+    "content-hash": "4b64522e03d82d970f9672580bc3c021",
     "packages": [
         {
             "name": "cboden/ratchet",
@@ -2999,6 +2999,66 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "ajgl/breakpoint-twig-extension",
+            "version": "0.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ajgarlag/AjglBreakpointTwigExtension.git",
+                "reference": "360ec6351ad7e1968ee78abb31430046c2e04fc5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ajgarlag/AjglBreakpointTwigExtension/zipball/360ec6351ad7e1968ee78abb31430046c2e04fc5",
+                "reference": "360ec6351ad7e1968ee78abb31430046c2e04fc5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "twig/twig": "^1.14|^2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5",
+                "symfony/framework-bundle": "^2.7|^3.2",
+                "symfony/twig-bundle": "^2.7|^3.2"
+            },
+            "suggest": {
+                "ext-xdebug": "The Xdebug extension is required for the breakpoint to work",
+                "symfony/framework-bundle": "The framework bundle to integrate the extension into Symfony",
+                "symfony/twig-bundle": "The twig bundle to integrate the extension into Symfony"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ajgl\\Twig\\Extension\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Antonio J. García Lagar",
+                    "email": "aj@garcialagar.es",
+                    "homepage": "http://aj.garcialagar.es",
+                    "role": "developer"
+                }
+            ],
+            "description": "Twig extension to set breakpoints",
+            "homepage": "https://github.com/ajgarlag/AjglBreakpointTwigExtension",
+            "keywords": [
+                "Xdebug",
+                "breakpoint",
+                "twig"
+            ],
+            "time": "2017-11-20T13:04:11+00:00"
+        },
         {
             "name": "behat/behat",
             "version": "v3.4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -1175,12 +1175,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/maciejczyzewski/bottomline.git",
-                "reference": "b20a5856870e2d32984dcb6c617522ca72afd559"
+                "reference": "1d1fa0d851f39310ccb2df55256aa4b7585adbcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maciejczyzewski/bottomline/zipball/b20a5856870e2d32984dcb6c617522ca72afd559",
-                "reference": "b20a5856870e2d32984dcb6c617522ca72afd559",
+                "url": "https://api.github.com/repos/maciejczyzewski/bottomline/zipball/1d1fa0d851f39310ccb2df55256aa4b7585adbcd",
+                "reference": "1d1fa0d851f39310ccb2df55256aa4b7585adbcd",
                 "shasum": ""
             },
             "require": {
@@ -1217,7 +1217,7 @@
                 "library",
                 "utility"
             ],
-            "time": "2017-11-27 15:08:12"
+            "time": "2018-02-10 09:58:57"
         },
         {
             "name": "michelf/php-markdown",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7036413c2f94fccc3ef363f26c60202",
+    "content-hash": "3388c53d025e86953b9614b05bfc2b06",
     "packages": [
         {
             "name": "cboden/ratchet",
@@ -1217,7 +1217,7 @@
                 "library",
                 "utility"
             ],
-            "time": "2017-11-27T15:08:12+00:00"
+            "time": "2017-11-27 15:08:12"
         },
         {
             "name": "michelf/php-markdown",
@@ -2841,6 +2841,109 @@
                 "templating"
             ],
             "time": "2017-09-27T18:06:46+00:00"
+        },
+        {
+            "name": "usmanhalalit/pixie",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/usmanhalalit/pixie.git",
+                "reference": "5820ef4f62c7be697767fd84830b7ad6fc057375"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/usmanhalalit/pixie/zipball/5820ef4f62c7be697767fd84830b7ad6fc057375",
+                "reference": "5820ef4f62c7be697767fd84830b7ad6fc057375",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "usmanhalalit/viocon": "1.0.*@dev"
+            },
+            "require-dev": {
+                "mockery/mockery": "0.9.4",
+                "phpunit/phpunit": "^4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Pixie": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Muhammad Usman",
+                    "email": "hi@usman.it",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Pavel Puchkin",
+                    "email": "i@neoascetic.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A lightweight, expressive, framework agnostic query builder for PHP.",
+            "homepage": "https://github.com/usmanhalalit/pixie",
+            "keywords": [
+                "database",
+                "mysql",
+                "postgresql",
+                "query builder",
+                "sql",
+                "sqlite"
+            ],
+            "time": "2016-04-08T10:58:01+00:00"
+        },
+        {
+            "name": "usmanhalalit/viocon",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/usmanhalalit/viocon.git",
+                "reference": "0878afee16f15355971fb95bf3c6d297aceff35d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/usmanhalalit/viocon/zipball/0878afee16f15355971fb95bf3c6d297aceff35d",
+                "reference": "0878afee16f15355971fb95bf3c6d297aceff35d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Viocon": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Muhammad Usman",
+                    "email": "hi@usman.it",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple and flexible Dependency Injection container for PHP.",
+            "homepage": "https://github.com/usmanhalalit/viocon",
+            "keywords": [
+                "container",
+                "di",
+                "ioc",
+                "test"
+            ],
+            "time": "2013-07-13T19:54:56+00:00"
         },
         {
             "name": "yzalis/identicon",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b64522e03d82d970f9672580bc3c021",
+    "content-hash": "07c65a4ec4714e941204979b2a79f13a",
     "packages": [
         {
             "name": "cboden/ratchet",
@@ -1535,6 +1535,70 @@
             "time": "2017-09-27T21:40:39+00:00"
         },
         {
+            "name": "pecee/pixie",
+            "version": "4.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/skipperbent/pecee-pixie.git",
+                "reference": "b6744599f8514eb4bb6d521155cb152242b5bd93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/skipperbent/pecee-pixie/zipball/b6744599f8514eb4bb6d521155cb152242b5bd93",
+                "reference": "b6744599f8514eb4bb6d521155cb152242b5bd93",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Pecee\\Pixie\\": "src/Pecee/Pixie/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Muhammad Usman",
+                    "email": "hi@usman.it",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Pavel Puchkin",
+                    "email": "i@neoascetic.me",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Simon Sessingø",
+                    "email": "simon.sessingoe@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Lightweight, fast query-builder for PHP based on Laravel Eloquent but with less overhead.",
+            "homepage": "https://github.com/skipperbent/pecee-pixie",
+            "keywords": [
+                "database",
+                "eloquent",
+                "mysql",
+                "pecee",
+                "pixie",
+                "postgresql",
+                "query builder",
+                "querybuilder",
+                "sql",
+                "sqlite"
+            ],
+            "time": "2018-01-16T23:53:01+00:00"
+        },
+        {
             "name": "phpcollection/phpcollection",
             "version": "0.5.0",
             "source": {
@@ -2841,109 +2905,6 @@
                 "templating"
             ],
             "time": "2017-09-27T18:06:46+00:00"
-        },
-        {
-            "name": "usmanhalalit/pixie",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/usmanhalalit/pixie.git",
-                "reference": "5820ef4f62c7be697767fd84830b7ad6fc057375"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/usmanhalalit/pixie/zipball/5820ef4f62c7be697767fd84830b7ad6fc057375",
-                "reference": "5820ef4f62c7be697767fd84830b7ad6fc057375",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "usmanhalalit/viocon": "1.0.*@dev"
-            },
-            "require-dev": {
-                "mockery/mockery": "0.9.4",
-                "phpunit/phpunit": "^4.8"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Pixie": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Muhammad Usman",
-                    "email": "hi@usman.it",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Pavel Puchkin",
-                    "email": "i@neoascetic.me",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A lightweight, expressive, framework agnostic query builder for PHP.",
-            "homepage": "https://github.com/usmanhalalit/pixie",
-            "keywords": [
-                "database",
-                "mysql",
-                "postgresql",
-                "query builder",
-                "sql",
-                "sqlite"
-            ],
-            "time": "2016-04-08T10:58:01+00:00"
-        },
-        {
-            "name": "usmanhalalit/viocon",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/usmanhalalit/viocon.git",
-                "reference": "0878afee16f15355971fb95bf3c6d297aceff35d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/usmanhalalit/viocon/zipball/0878afee16f15355971fb95bf3c6d297aceff35d",
-                "reference": "0878afee16f15355971fb95bf3c6d297aceff35d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "3.7.*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Viocon": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Muhammad Usman",
-                    "email": "hi@usman.it",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A simple and flexible Dependency Injection container for PHP.",
-            "homepage": "https://github.com/usmanhalalit/viocon",
-            "keywords": [
-                "container",
-                "di",
-                "ioc",
-                "test"
-            ],
-            "time": "2013-07-13T19:54:56+00:00"
         },
         {
             "name": "yzalis/identicon",

--- a/composer.lock
+++ b/composer.lock
@@ -5496,13 +5496,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6",
+        "php": ">=7.0.9",
         "ext-pdo": "*",
         "ext-gd": "*",
         "ext-pdo_mysql": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.0"
+        "php": "7.0.9"
     }
 }

--- a/controllers/BanController.php
+++ b/controllers/BanController.php
@@ -15,11 +15,13 @@ class BanController extends CRUDController
         $currentPage = $this->getCurrentPage();
 
         $qb = $this->getQueryBuilder()
-            ->sortBy('updated')->reverse()
-            ->limit(16)->fromPage($currentPage);
+            ->orderBy('updated', 'DESC')
+            ->limit(16)
+            ->fromPage($currentPage)
+        ;
 
         return array(
-            'bans'        => $qb->getModels(),
+            'bans'        => $qb->getModels(true),
             'currentPage' => $currentPage,
             'totalPages'  => $qb->countPages()
         );

--- a/controllers/MapController.php
+++ b/controllers/MapController.php
@@ -5,17 +5,18 @@ class MapController extends CRUDController
     public function listAction(Map $map = null)
     {
         if ($map === null) {
-            $qb = $this->getQueryBuilder();
-
-            $maps = $qb->sortBy('name')
-                ->getModels();
+            $maps = $this->getQueryBuilder()
+                ->active()
+                ->orderBy('name')
+                ->getModels()
+            ;
         } else {
-            $maps = array($map);
+            $maps = [$map];
         }
 
-        return array(
-            "maps" => $maps
-        );
+        return [
+            'maps' => $maps
+        ];
     }
 
     public function createAction(Player $me)

--- a/controllers/NewsController.php
+++ b/controllers/NewsController.php
@@ -61,8 +61,9 @@ class NewsController extends CRUDController
 
     private function getCategories()
     {
-        return $this->getQueryBuilder('NewsCategory')
-            ->sortBy('name')
-            ->getModels();
+        return NewsCategory::getQueryBuilder()
+            ->orderBy('name')
+            ->getModels(true)
+        ;
     }
 }

--- a/controllers/NewsController.php
+++ b/controllers/NewsController.php
@@ -4,29 +4,44 @@ use Symfony\Component\HttpFoundation\Request;
 
 class NewsController extends CRUDController
 {
-    public function showAction(News $article)
+    public function showAction(Player $me, News $article)
     {
-        return array("article" => $article, "categories" => $this->getCategories());
+        if ($article->isDraft() && (!$me->isValid() || !$me->hasPermission(News::EDIT_PERMISSION))) {
+            throw new ForbiddenException('You do not have permission to view draft posts.');
+        }
+
+        return [
+            'article' => $article,
+            'categories' => $this->getCategories(),
+        ];
     }
 
-    public function listAction(Request $request, NewsCategory $category = null)
+    public function listAction(Request $request, Player $me, NewsCategory $category = null)
     {
+        $currentPage = $this->getCurrentPage();
         $qb = $this->getQueryBuilder();
 
-        $currentPage = $this->getCurrentPage();
+        $news = $qb
+            ->orderBy('created', 'DESC')
+            ->limit(5)
+            ->fromPage($currentPage)
+        ;
 
-        $news = $qb->sortBy('created')->reverse()
-            ->where('category')->is($category)
-            ->limit(5)->fromPage($currentPage)
-            ->getModels();
+        if ($category !== null) {
+            $news->where('category', '=', $category->getId());
+        }
 
-        return array(
-            "news"        => $news,
-            "categories"  => $this->getCategories(),
-            "category"    => $category,
-            "currentPage" => $currentPage,
-            "totalPages"  => $qb->countPages()
-        );
+        if (!$me->isValid() || !$me->hasPermission(News::CREATE_PERMISSION)) {
+            $news->whereNot('is_draft', '=', true);
+        }
+
+        return [
+            'news'        => $news->getModels(true),
+            'categories'  => $this->getCategories(),
+            'category'    => $category,
+            'currentPage' => $currentPage,
+            'totalPages'  => $qb->countPages(),
+        ];
     }
 
     public function createAction(Player $me)

--- a/controllers/PageController.php
+++ b/controllers/PageController.php
@@ -18,7 +18,9 @@ class PageController extends CRUDController
 
     public function showAction(Page $page)
     {
-        return array("page" => $page);
+        return [
+            'page' => $page
+        ];
     }
 
     public function createAction(Player $me, Request $request)

--- a/controllers/PlayerController.php
+++ b/controllers/PlayerController.php
@@ -50,7 +50,7 @@ class PlayerController extends JSONController
         }
 
         $bans = Ban::getQueryBuilder()
-            ->where('player')->is($player->getId())
+            ->where('player', '=', $player->getId())
             ->getModels($fast = true)
         ;
 

--- a/controllers/PlayerController.php
+++ b/controllers/PlayerController.php
@@ -84,12 +84,13 @@ class PlayerController extends JSONController
         Country::getQueryBuilder()->addToCache();
 
         if ($team) {
-            $query->where('team')->is($team);
+            $query->where('team', '=', $team);
         } else {
             // Add all teams to the cache
-            $this->getQueryBuilder('Team')
-                ->where('members')->greaterThan(0)
-                ->addToCache();
+            Team::getQueryBuilder()
+                ->where('members', '>', 0)
+                ->addToCache()
+            ;
         }
 
         if ($request->query->has('exceptMe')) {
@@ -103,24 +104,18 @@ class PlayerController extends JSONController
         $query
             ->active()
             ->withMatchActivity()
-            ->sortBy('name')
+            ->orderBy('username')
         ;
 
         if (!$request->query->get('showAll')) {
-            $query->having('activity')->greaterThan(0);
+            $query->having('activity', '>', 0);
         }
 
         if ($sortBy || $sortOrder) {
-            $sortBy = $sortBy ? $sortBy : 'callsign';
-            $sortOrder = $sortOrder ? $sortOrder : 'ASC';
+            $sortBy = $sortBy ? 'activity' : 'callsign';
+            $sortOrder = $sortOrder ? 'DESC' : 'ASC';
 
-            if ($sortBy === 'activity') {
-                $query->sortBy($sortBy);
-            }
-
-            if ($sortOrder == 'DESC') {
-                $query->reverse();
-            }
+            $query->orderBy($sortBy, $sortOrder);
         }
 
         $players = $query->getModels($fast = true);

--- a/controllers/ServerController.php
+++ b/controllers/ServerController.php
@@ -10,7 +10,8 @@ class ServerController extends CRUDController
     {
         $servers = $this
             ->getQueryBuilder()
-            ->sortBy('name')
+            ->active()
+            ->orderBy('name')
             ->getModels()
         ;
 

--- a/controllers/TeamController.php
+++ b/controllers/TeamController.php
@@ -34,23 +34,31 @@ class TeamController extends CRUDController
         ];
     }
 
+    /**
+     * @param Request $request
+     *
+     * @throws \Pecee\Pixie\Exception
+     * @throws Exception
+     *
+     * @return array
+     */
     public function listAction(Request $request)
     {
         $teamQB = Team::getQueryBuilder()
             ->active()
-            ->sortBy('elo')->reverse()
+            ->orderBy('elo', 'DESC')
         ;
 
         // Cache team captains so we don't fetch each manually
         $captains = $teamQB->getArray('leader');
         $captIDs = array_column($captains, 'leader');
         Player::getQueryBuilder()
-            ->where('id')->isOneOf($captIDs)
+            ->whereIn('id', $captIDs)
             ->addToCache()
         ;
 
         return [
-            'teams'   => $teamQB->withMatchActivity()->getModels($fast = true),
+            'teams'   => $teamQB->withMatchActivity()->getModels(),
             'showAll' => (bool)$request->get('showAll', false),
         ];
     }

--- a/controllers/VisitLogController.php
+++ b/controllers/VisitLogController.php
@@ -13,8 +13,7 @@ class VisitLogController extends HTMLController
 
     public function listAction(Request $request)
     {
-        /** @var VisitQueryBuilder $qb */
-        $qb = $this->getQueryBuilder();
+        $qb = Visit::getQueryBuilder();
 
         $currentPage = $this->getCurrentPage();
 
@@ -22,20 +21,17 @@ class VisitLogController extends HTMLController
             $qb->search($request->query->get('search'));
         }
 
-        $visits = $qb->sortBy('timestamp')->reverse()
+        $visits = $qb
+            ->orderBy('timestamp', 'DESC')
             ->limit(30)->fromPage($currentPage)
-            ->getModels($fast = true);
+            ->getModels()
+        ;
 
-        return array(
-            "visits"      => $visits,
-            "currentPage" => $currentPage,
-            "totalPages"  => $qb->countPages(),
-            "search"      => $request->query->get('search')
-        );
-    }
-
-    public static function getQueryBuilder($type = "Visit")
-    {
-        return $type::getQueryBuilder();
+        return [
+            'visits'      => $visits,
+            'currentPage' => $currentPage,
+            'totalPages'  => $qb->countPages(),
+            'search'      => $request->query->get('search')
+        ];
     }
 }

--- a/migrations/20180201224448_bans_status_column_conversion.php
+++ b/migrations/20180201224448_bans_status_column_conversion.php
@@ -1,0 +1,50 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class BansStatusColumnConversion extends AbstractMigration
+{
+    public function up()
+    {
+        $bansTable = $this->table('bans');
+        $bansTable
+            ->addColumn('is_deleted', 'boolean', [
+                'after' => 'is_soft_ban',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not the ban has been deleted',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE bans SET is_deleted = 1 WHERE status = 'deleted';");
+
+        $bansTable
+            ->removeColumn('status')
+            ->update()
+        ;
+    }
+
+    public function down()
+    {
+        $bansTable = $this->table('bans');
+        $bansTable
+            ->addColumn('status', 'set', [
+                'values' => ['public', 'hidden', 'deleted'],
+                'after' => 'is_soft_ban',
+                'null' => false,
+                'default' => 'public',
+                'comment' => 'The status of the ban element',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE bans SET status = 'deleted' WHERE is_deleted = true;");
+
+        $bansTable
+            ->removeColumn('is_deleted')
+            ->update()
+        ;
+    }
+}

--- a/migrations/20180202080131_allow_country_deletion.php
+++ b/migrations/20180202080131_allow_country_deletion.php
@@ -1,0 +1,21 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class AllowCountryDeletion extends AbstractMigration
+{
+    public function change()
+    {
+        $countriesTable = $this->table('countries');
+        $countriesTable
+            ->addColumn('is_deleted', 'boolean', [
+                'after' => 'name',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not the country has been deleted',
+            ])
+            ->update()
+        ;
+    }
+}

--- a/migrations/20180202213952_news_status_column_conversion.php
+++ b/migrations/20180202213952_news_status_column_conversion.php
@@ -1,0 +1,67 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class NewsStatusColumnConversion extends AbstractMigration
+{
+    public function up()
+    {
+        $newsTable = $this->table('news');
+        $newsTable
+            ->addColumn('is_draft', 'boolean', [
+                'after' => 'editor',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not the news article is a draft',
+            ])
+            ->addColumn('is_deleted', 'boolean', [
+                'after' => 'is_draft',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not the news article has been soft deleted',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE news SET is_draft = 1 WHERE status = 'revision' OR status ='draft';");
+        $this->query("UPDATE news SET is_deleted = 1 WHERE status = 'deleted' OR status = 'disabled';");
+
+        $newsTable
+            ->removeColumn('parent_id')
+            ->removeColumn('status')
+            ->update()
+        ;
+    }
+
+    public function down()
+    {
+        $newsTable = $this->table('news');
+        $newsTable
+            ->addColumn('parent_id', 'integer', [
+                'after' => 'id',
+                'null' => true,
+                'default' => null,
+                'length' => 11,
+                'comment' => 'The ID of the original news post. If this column is set, then it is a revision',
+            ])
+            ->addColumn('status', 'set', [
+                'values' => ['published', 'revision', 'draft', 'disabled', 'deleted'],
+                'after' => 'editor',
+                'null' => false,
+                'default' => 'published',
+                'comment' => 'The status of the news element',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE news SET status = 'draft' WHERE is_draft = 1;");
+        $this->query("UPDATE news SET status = 'deleted' WHERE is_deleted = 1;");
+
+        $newsTable
+            ->removeColumn('is_draft')
+            ->removeColumn('is_deleted')
+            ->update()
+        ;
+    }
+}

--- a/migrations/20180206040040_news_category_status_column_conversion.php
+++ b/migrations/20180206040040_news_category_status_column_conversion.php
@@ -1,0 +1,63 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class NewsCategoryStatusColumnConversion extends AbstractMigration
+{
+    public function up()
+    {
+        $newsCategoryTable = $this->table('news_categories');
+        $newsCategoryTable
+            ->addColumn('is_read_only', 'boolean', [
+                'after' => 'protected',
+                'null' => false,
+                'default' => false,
+                'comment' => 'When set to true, no new articles should be able to use this category'
+            ])
+            ->addColumn('is_deleted', 'boolean', [
+                'after' => 'is_read_only',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not the news category has been soft deleted',
+            ])
+            ->changeColumn('protected', 'boolean', [
+                'default' => false,
+                'null' => false,
+                'comment' => 'When set to true, prevents the category from being deleted from the UI',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE news_categories SET is_deleted = 1 WHERE status = 'deleted';");
+
+        $newsCategoryTable
+            ->removeColumn('status')
+            ->renameColumn('protected', 'is_protected')
+            ->update()
+        ;
+    }
+
+    public function down()
+    {
+        $newsCategoryTable = $this->table('news_categories');
+        $newsCategoryTable
+            ->addColumn('status', 'set', [
+                'values' => ['enabled', 'disabled', 'deleted'],
+                'after' => 'is_deleted',
+                'null' => false,
+                'default' => 'enabled',
+                'comment' => 'The status of the news element',
+            ])
+            ->renameColumn('is_protected', 'protected')
+            ->update()
+        ;
+
+        $this->query("UPDATE news_categories SET status = 'deleted' WHERE is_deleted = 1;");
+
+        $newsCategoryTable
+            ->removeColumn('is_deleted')
+            ->removeColumn('is_read_only')
+            ->update()
+        ;
+    }
+}

--- a/migrations/20180208072640_page_status_conversion.php
+++ b/migrations/20180208072640_page_status_conversion.php
@@ -1,0 +1,81 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class PageStatusConversion extends AbstractMigration
+{
+    public function up()
+    {
+        $pagesTable = $this->table('pages');
+        $pagesTable
+            ->addColumn('is_unlisted', 'boolean', [
+                'after' => 'home',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this page should be listed in the secondary navigation',
+            ])
+            ->addColumn('is_draft', 'boolean', [
+                'after' => 'is_unlisted',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not the news article is a draft',
+            ])
+            ->addColumn('is_deleted', 'boolean', [
+                'after' => 'is_draft',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this entry has been soft-deleted',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE pages SET is_deleted = 1 WHERE status = 'deleted';");
+        $this->query("UPDATE pages SET is_unlisted = 1 WHERE status = 'revision';");
+
+        $pagesTable
+            ->removeColumn('parent_id')
+            ->removeColumn('home')
+            ->removeColumn('status')
+            ->update()
+        ;
+    }
+
+    public function down()
+    {
+        $pagesTable = $this->table('pages');
+        $pagesTable
+            ->addColumn('parent_id', 'integer', [
+                'after' => 'id',
+                'null' => true,
+                'default' => null,
+                'length' => 10,
+                'comment' => 'The ID of the original page. If this column is set, then it is a revision',
+            ])
+            ->addColumn('home', 'integer', [
+                'after' => 'author',
+                'length' => 4,
+                'null' => true,
+                'default' => null,
+                'comment' => '(Deprecated) Whether or not the page is the home page',
+            ])
+            ->addColumn('status', 'set', [
+                'values' => ['live', 'revision', 'disabled', 'deleted'],
+                'after' => 'home',
+                'null' => false,
+                'default' => 'live',
+                'comment' => 'The status of this page',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE pages SET status = 'deleted' WHERE is_deleted = 1");
+        $this->query("UPDATE pages SET status = 'revision' WHERE is_unlisted = 1");
+
+        $pagesTable
+            ->removeColumn('is_unlisted')
+            ->removeColumn('is_draft')
+            ->removeColumn('is_deleted')
+            ->update()
+        ;
+    }
+}

--- a/migrations/20180209070716_make_invitations_better.php
+++ b/migrations/20180209070716_make_invitations_better.php
@@ -1,0 +1,48 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class MakeInvitationsBetter extends AbstractMigration
+{
+    public function change()
+    {
+        $invitationsTable = $this->table('invitations');
+        $invitationsTable
+            ->addColumn('sent', 'datetime', [
+                'after' => 'team',
+                'null' => true,
+                'default' => null,
+                'comment' => 'When the invitation was sent',
+            ])
+            ->addColumn('status', 'integer', [
+                'after' => 'text',
+                'null' => false,
+                'default' => 0,
+                'signed' => true,
+                'length' => 1,
+                'comment' => '0: pending; 1: accepted; 2: rejected',
+            ])
+            ->addColumn('is_deleted', 'boolean', [
+                'after' => 'status',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not the invitation has been soft deleted',
+            ])
+            ->update()
+        ;
+
+        $invitationsTable
+            ->renameColumn('text', 'message')
+            ->update()
+        ;
+
+        $invitationsTable
+            ->changeColumn('message', 'text', [
+                'null' => true,
+                'default' => null,
+                'comment' => 'The message sent when inviting a player to a team',
+            ])
+            ->update()
+        ;
+    }
+}

--- a/migrations/20180210222728_maps_status_column_conversion.php
+++ b/migrations/20180210222728_maps_status_column_conversion.php
@@ -1,0 +1,56 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class MapsStatusColumnConversion extends AbstractMigration
+{
+    public function up()
+    {
+        $mapsTable = $this->table('maps');
+        $mapsTable
+            ->addColumn('is_inactive', 'boolean', [
+                'after' => 'game_mode',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this map has been marked as inactive, meaning a map is no longer in active rotation on servers',
+            ])
+            ->addColumn('is_deleted', 'boolean', [
+                'after' => 'is_inactive',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this map has been soft deleted'
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE maps SET is_inactive = 1 WHERE status = 'hidden' OR status = 'disabled';");
+        $this->query("UPDATE maps SET is_deleted = 1 WHERE status = 'deleted';");
+
+        $mapsTable
+            ->removeColumn('status')
+            ->update()
+        ;
+    }
+
+    public function down()
+    {
+        $mapsTable = $this->table('maps');
+        $mapsTable
+            ->addColumn('status', 'set', [
+                'values' => ['active', 'hidden', 'disabled', 'deleted'],
+                'null' => false,
+                'default' => 'active',
+                'comment' => 'The status of the map',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE maps SET status = 'hidden' WHERE is_inactive = 1;");
+        $this->query("UPDATE maps SET status = 'deleted' WHERE is_deleted = 1;");
+
+        $mapsTable
+            ->removeColumn('is_inactive')
+            ->removeColumn('is_deleted')
+        ;
+    }
+}

--- a/migrations/20180211020823_server_status_column_conversation.php
+++ b/migrations/20180211020823_server_status_column_conversation.php
@@ -1,0 +1,73 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ServerStatusColumnConversation extends AbstractMigration
+{
+    public function up()
+    {
+        $serversTable = $this->table('servers');
+        $serversTable
+            ->addColumn('is_official_server', 'boolean', [
+                'after' => 'updated',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this server is capable of hosting official matches',
+            ])
+            ->addColumn('is_replay_server', 'boolean', [
+                'after' => 'is_official_server',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this server is dedicated to serving replays of matches',
+            ])
+            ->addColumn('is_inactive', 'boolean', [
+                'after' => 'is_replay_server',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this server is no longer active but still required for historical purposes',
+
+            ])
+            ->addColumn('is_deleted', 'boolean', [
+                'after' => 'is_inactive',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this server has been soft deleted',
+            ])
+            ->update()
+        ;
+
+        // BZiON 0.10.x and below required that you soft deleted servers so they'd no longer appear on the server list.
+        // For this reason and because Leagues United is the only known installation, we'll be assuming that deleted
+        // servers were just meant to be marked as "inactive."
+        $this->query("UPDATE servers SET is_inactive = 1 WHERE status = 'deleted';");
+
+        $serversTable
+            ->removeColumn('status')
+            ->update()
+        ;
+    }
+
+    public function down()
+    {
+        $serversTable = $this->table('servers');
+        $serversTable
+            ->addColumn('status', 'set', [
+                'values' => ['active', 'disabled', 'deleted'],
+                'null' => false,
+                'default' => 'active',
+                'comment' => 'The status of the server relative to BZiON',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE servers SET status = 'deleted' WHERE is_inactive = 1;");
+
+        $serversTable
+            ->removeColumn('is_official_server')
+            ->removeColumn('is_replay_server')
+            ->removeColumn('is_inactive')
+            ->removeColumn('is_deleted')
+            ->update()
+        ;
+    }
+}

--- a/migrations/20180212044818_team_status_column_conversion.php
+++ b/migrations/20180212044818_team_status_column_conversion.php
@@ -1,0 +1,57 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class TeamStatusColumnConversion extends AbstractMigration
+{
+    public function up()
+    {
+        $teamsTable = $this->table('teams');
+        $teamsTable
+            ->addColumn('is_closed', 'boolean', [
+                'after' => 'members',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this team is closed',
+            ])
+            ->addColumn('is_deleted', 'boolean', [
+                'after' => 'is_closed',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this team has been soft deleted',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE teams SET is_closed = 1 WHERE status = 'closed';");
+        $this->query("UPDATE teams SET is_deleted = 1 WHERE status = 'deleted';");
+
+        $teamsTable
+            ->removeColumn('status')
+            ->update()
+        ;
+    }
+
+    public function down()
+    {
+        $teamsTable = $this->table('teams');
+        $teamsTable
+            ->addColumn('status', 'set', [
+                'values' => ['open', 'closed', 'disabled', 'deleted'],
+                'null' => false,
+                'default' => 'open',
+                'comment' => 'The status of the team',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE teams SET status = 'deleted' WHERE is_deleted = 1;");
+        $this->query("UPDATE teams SET status = 'closed' WHERE is_closed = 1;");
+
+        $teamsTable
+            ->removeColumn('is_closed')
+            ->removeColumn('is_deleted')
+            ->update()
+        ;
+    }
+}

--- a/migrations/20180214080518_player_status_column_conversion.php
+++ b/migrations/20180214080518_player_status_column_conversion.php
@@ -1,0 +1,57 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class PlayerStatusColumnConversion extends AbstractMigration
+{
+    public function up()
+    {
+        $playersTable = $this->table('players');
+        $playersTable
+            ->addColumn('is_disabled', 'boolean', [
+                'after' => 'last_login',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this account has been disabled by an admin and cannot log in',
+            ])
+            ->addColumn('is_deleted', 'boolean', [
+                'after' => 'is_disabled',
+                'null' => false,
+                'default' => false,
+                'comment' => 'Whether or not this player has been soft-deleted',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE players SET is_deleted = 1 WHERE status = 'deleted';");
+        $this->query("UPDATE players SET is_disabled = 1 WHERE status = 'disabled';");
+
+        $playersTable
+            ->removeColumn('status')
+            ->update()
+        ;
+    }
+
+    public function down()
+    {
+        $playersTable = $this->table('players');
+        $playersTable
+            ->addColumn('status', 'set', [
+                'values' => ['active','disabled','deleted','reported','banned','test'],
+                'null' => false,
+                'default' => 'active',
+                'comment' => 'The status of this player',
+            ])
+            ->update()
+        ;
+
+        $this->query("UPDATE players SET status = 'deleted' WHERE is_deleted = 1;");
+        $this->query("UPDATE players SET status = 'disabled' WHERE is_disabled = 1;");
+
+        $playersTable
+            ->removeColumn('is_disabled')
+            ->removeColumn('is_deleted')
+            ->update()
+        ;
+    }
+}

--- a/models/Ban.php
+++ b/models/Ban.php
@@ -66,13 +66,9 @@ class Ban extends UrlModel implements NamedModel
      */
     protected $ipAddresses;
 
-    /**
-     * The ban's status
-     * @var string
-     */
-    protected $status;
-
     const DEFAULT_STATUS = 'public';
+
+    const DELETED_COLUMN = 'is_deleted';
 
     /**
      * The name of the database table used for queries
@@ -97,7 +93,7 @@ class Ban extends UrlModel implements NamedModel
         $this->created = TimeDate::fromMysql($ban['created']);
         $this->updated = TimeDate::fromMysql($ban['updated']);
         $this->author = $ban['author'];
-        $this->status = $ban['status'];
+        $this->is_deleted = $ban['is_deleted'];
     }
 
     /**

--- a/models/Ban.php
+++ b/models/Ban.php
@@ -391,17 +391,13 @@ class Ban extends UrlModel implements NamedModel
     /**
      * Get a query builder for news
      *
-     * @return QueryBuilder
+     * @throws Exception
+     *
+     * @return QueryBuilderFlex
      */
     public static function getQueryBuilder()
     {
-        return new QueryBuilder('Ban', array(
-            'columns' => array(
-                'player'  => 'player',
-                'status'  => 'status',
-                'updated' => 'updated'
-            ),
-        ));
+        return QueryBuilderFlex::createForModel(Ban::class);
     }
 
     /**

--- a/models/Country.php
+++ b/models/Country.php
@@ -8,26 +8,17 @@
 
 /**
  * A country
- * @package    BZiON\Models
  */
-class Country extends Model
+class Country extends Model implements NamedModel
 {
-    /**
-     * The name of the country
-     * @var string
-     */
+    /** @var string The name of the country */
     protected $name;
 
-    /**
-     * The ISO code of the country
-     * @var string
-     */
+    /** @var string The ISO code of the country */
     protected $iso;
 
-    /**
-     * The name of the database table used for queries
-     */
-    const TABLE = "countries";
+    const DELETED_COLUMN = 'is_deleted';
+    const TABLE = 'countries';
 
     /**
      * {@inheritdoc}
@@ -69,31 +60,6 @@ class Country extends Model
     }
 
     /**
-     * Get all the countries in the database
-     *
-     * @return Country[] An array of country objects
-     */
-    public static function getCountries()
-    {
-        return self::arrayIdToModel(self::fetchIds());
-    }
-
-    /**
-     * Get an associative array with country ISO code as keys and country names
-     * as values
-     *
-     * @return array
-     */
-    public static function getCountriesWithISO()
-    {
-        $result = Database::getInstance()->query(
-            'SELECT iso, name from ' . static::TABLE
-        );
-
-        return array_column($result, 'name', 'iso');
-    }
-
-    /**
      * Get the country's flag's CSS class
      *
      * @return string The URL to the country's flag
@@ -104,28 +70,16 @@ class Country extends Model
     }
 
     /**
-     * Given a country's ISO, get its ID
-     *
-     * @param  string $iso The two-letter ISO code of the country
-     * @return int    The country's database ID
-     */
-    public static function getIdFromISO($iso)
-    {
-        return self::fetchIdFrom($iso, 'iso');
-    }
-
-    /**
      * Get a query builder for countries
      *
-     * @return QueryBuilder
+     * @throws Exception When no database is configured for BZiON
+     *
+     * @return QueryBuilderFlex
      */
     public static function getQueryBuilder()
     {
-        return new QueryBuilder('Country', array(
-            'columns' => array(
-                'name' => 'name',
-            ),
-            'name' => 'name',
-        ));
+        return QueryBuilderFlex::createForModel(Country::class)
+            ->setNameColumn('name')
+        ;
     }
 }

--- a/models/Invitation.php
+++ b/models/Invitation.php
@@ -28,7 +28,13 @@ class Invitation extends UrlModel
      * The ID of the team a player was invited to
      * @var int
      */
-    protected $team;
+    protected $team_id;
+
+    /**
+     * The time the invitation was sent
+     * @var TimeDate
+     */
+    protected $sent;
 
     /**
      * The time the invitation will expire
@@ -40,13 +46,27 @@ class Invitation extends UrlModel
      * The optional message sent to a player to join a team
      * @var string
      */
-    protected $text;
+    protected $message;
 
     /**
-     * The name of the database table used for queries
+     * @var int
      */
+    protected $status;
 
-    const TABLE = "invitations";
+    /**
+     * An array of valid statuses an Invitation can be in.
+     *
+     * @var int[]
+     */
+    protected static $validStatuses = [self::STATUS_PENDING, self::STATUS_ACCEPTED, self::STATUS_DENIED];
+
+    const DELETED_COLUMN = 'is_deleted';
+
+    const STATUS_PENDING = 0;
+    const STATUS_ACCEPTED = 1;
+    const STATUS_DENIED = 2;
+
+    const TABLE = 'invitations';
 
     /**
      * {@inheritdoc}
@@ -55,37 +75,19 @@ class Invitation extends UrlModel
     {
         $this->invited_player = $invitation['invited_player'];
         $this->sent_by    = $invitation['sent_by'];
-        $this->team       = $invitation['team'];
+        $this->team_id    = $invitation['team'];
+        $this->sent       = TimeDate::fromMysql($invitation['sent']);
         $this->expiration = TimeDate::fromMysql($invitation['expiration']);
-        $this->text       = $invitation['text'];
+        $this->status     = self::castStatus($invitation['status']);
+        $this->is_deleted = $invitation['is_deleted'];
     }
 
     /**
-     * Send an invitation to join a team
-     * @param  int        $to      The ID of the player who will receive the invitation
-     * @param  int        $teamid  The team ID to which a player has been invited to
-     * @param  int|null   $from    The ID of the player who sent it
-     * @param  string     $message (Optional) The message that will be displayed to the person receiving the invitation
-     * @param  string|TimeDate|null $expiration The expiration time of the invitation (defaults to 1 week from now)
-     * @return Invitation The object of the invitation just sent
+     * {@inheritdoc}
      */
-    public static function sendInvite($to, $teamid, $from = null, $message = "", $expiration = null)
+    protected function assignLazyResult($invitation)
     {
-        if ($expiration === null) {
-            $expiration = TimeDate::now()->addWeek();
-        } else {
-            $expiration = Timedate::from($expiration);
-        }
-
-        $invitation = self::create(array(
-            "invited_player" => $to,
-            "sent_by"        => $from,
-            "team"           => $teamid,
-            "text"           => $message,
-            "expiration"     => $expiration->toMysql(),
-        ));
-
-        return $invitation;
+        $this->message = $invitation['text'];
     }
 
     /**
@@ -115,7 +117,17 @@ class Invitation extends UrlModel
      */
     public function getTeam()
     {
-        return Team::get($this->team);
+        return Team::get($this->team_id);
+    }
+
+    /**
+     * Get the timestamp of when the invitation was sent.
+     *
+     * @return TimeDate
+     */
+    public function getSendTimestamp()
+    {
+        return $this->sent;
     }
 
     /**
@@ -129,37 +141,179 @@ class Invitation extends UrlModel
     }
 
     /**
+     * Get the optional message sent to a player to join a team
+     *
+     * @return string
+     */
+    public function getMessage()
+    {
+        $this->lazyLoad();
+
+        return $this->message;
+    }
+
+    /**
+     * Get the current status of the Invitation.
+     *
+     * @see Invitation::STATUS_PENDING
+     * @see Invitation::STATUS_ACCEPTED
+     * @see Invitation::STATUS_DENIED
+     *
+     * @since 0.11.0
+     *
+     * @return int
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * Whether or not an invitation has expired
+     *
+     * @return bool
+     */
+    public function isExpired()
+    {
+        return $this->expiration->lt(TimeDate::now());
+    }
+
+    /**
      * Mark the invitation as having expired
      *
      * @return self
      */
-    public function updateExpiration()
+    public function setExpired()
     {
         return $this->updateProperty($this->expiration, 'expiration', TimeDate::now());
     }
 
     /**
-     * Get the optional message sent to a player to join a team
+     * Update the status for this Invitation
      *
-     * @return string
+     * @param int $statusValue
+     *
+     * @see Invitation::STATUS_PENDING
+     * @see Invitation::STATUS_ACCEPTED
+     * @see Invitation::STATUS_DENIED
+     *
+     * @since 0.11.0
+     *
+     * @throws InvalidArgumentException When an invalid status is given as an argument
+     *
+     * @return static
      */
-    public function getText()
+    public function setStatus($statusValue)
     {
-        return $this->text;
+        if (!in_array($statusValue, self::$validStatuses)) {
+            throw new InvalidArgumentException('Invalid value was used; see Invitation::$validStatuses for valid values.');
+        }
+
+        return $this->updateProperty($this->status, 'status', $statusValue);
+    }
+
+    /**
+     * Send an invitation to join a team
+     *
+     * @param  int        $playerID The ID of the player who will receive the invitation
+     * @param  int        $teamID   The team ID to which a player has been invited to
+     * @param  int|null   $from     The ID of the player who sent it
+     * @param  string     $message  (Optional) The message that will be displayed to the person receiving the invitation
+     * @param  string|TimeDate|null $expiration The expiration time of the invitation (defaults to 1 week from now)
+     *
+     * @return Invitation The object of the invitation just sent
+     */
+    public static function sendInvite($playerID, $teamID, $from = null, $message = '', $expiration = null)
+    {
+        if ($expiration === null) {
+            $expiration = TimeDate::now()->addWeek();
+        } else {
+            $expiration = Timedate::from($expiration);
+        }
+
+        $invitation = self::create([
+            'invited_player' => $playerID,
+            'sent_by'        => $from,
+            'team'           => $teamID,
+            'sent'           => TimeDate::now()->toMysql(),
+            'expiration'     => $expiration->toMysql(),
+            'message'        => $message,
+            'status'         => self::STATUS_PENDING,
+        ]);
+
+        return $invitation;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getQueryBuilder()
+    {
+        return QueryBuilderFlex::createForModel(Invitation::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getEagerColumnsList()
+    {
+        return [
+            'id',
+            'invited_player',
+            'sent_by',
+            'team',
+            'sent',
+            'expiration',
+            'status',
+            'is_deleted',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getLazyColumnsList()
+    {
+        return [
+            'message',
+        ];
     }
 
     /**
      * Find whether there are unexpired invitations for a player and a team
      *
-     * @param  int $player
-     * @param  int $team
+     * @param  Player|int $player
+     * @param  Team|int $team
+     *
      * @return int
      */
-    public static function hasOpenInvitation($player, $team)
+    public static function playerHasInvitationToTeam($player, $team)
     {
-        return self::fetchCount(
-            "WHERE invited_player = ? AND team = ? AND expiration > UTC_TIMESTAMP()",
-            array($player, $team)
-        );
+        return (bool)self::getQueryBuilder()
+            ->where('invited_player', '=', $player)
+            ->where('team', '=', $team)
+            ->where('expiration', '<', 'UTC_TIMESTAMP()')
+            ->count()
+        ;
+    }
+
+    /**
+     * Cast a value to a valid Invitation status.
+     *
+     * @param int $status
+     *
+     * @see Invitation::STATUS_PENDING
+     * @see Invitation::STATUS_ACCEPTED
+     * @see Invitation::STATUS_DENIED
+     *
+     * @return int
+     */
+    protected static function castStatus($status)
+    {
+        if (in_array($status, self::$validStatuses)) {
+            return $status;
+        }
+
+        return self::STATUS_PENDING;
     }
 }

--- a/models/NewsCategory.php
+++ b/models/NewsCategory.php
@@ -97,22 +97,25 @@ class NewsCategory extends AliasModel
      * @param int  $limit     The amount of matches to be retrieved
      * @param bool $getDrafts Whether or not to fetch drafts
      *
+     * @throws \Pixie\Exception
+     * @throws Exception
+     *
      * @return News[] An array of news objects
      */
     public function getNews($start = 0, $limit = 5, $getDrafts = false)
     {
-        $ignoredStatuses = "";
+        $qb = News::getQueryBuilder()
+            ->limit($limit)
+            ->offset($start)
+            ->active()
+            ->where('category', '=', $this->getId())
+        ;
 
-        if (!$getDrafts) {
-            $ignoredStatuses = "'draft', ";
+        if ($getDrafts) {
+            $qb->whereNot('is_draft', '=', true);
         }
 
-        $ignoredStatuses .= "'deleted'";
-
-        $query  = "WHERE status NOT IN ($ignoredStatuses) AND category = ? ";
-        $query .= "ORDER BY created DESC LIMIT $limit OFFSET $start";
-
-        return News::arrayIdToModel(News::fetchIds($query, array($this->getId())));
+        return $qb->getModels(true);
     }
 
     /**

--- a/models/Permission.php
+++ b/models/Permission.php
@@ -10,7 +10,7 @@
  * A permission that is assigned to a role
  * @package    BZiON\Models
  */
-class Permission extends Model
+class Permission extends Model implements NamedModel
 {
     const ADD_BAN            = "add_ban";
     const ADD_MAP            = "add_map";
@@ -67,9 +67,7 @@ class Permission extends Model
      */
     protected $description;
 
-    /**
-     * The name of the database table used for queries
-     */
+    const SYSTEM_MODEL = true;
     const TABLE = "permissions";
 
     /**
@@ -101,13 +99,16 @@ class Permission extends Model
 
     /**
      * Get all of the existing permissions in the database
+     *
+     * @throws \Pixie\Exception
+     *
      * @return Permission[] An array of permissions
      */
     public static function getPerms()
     {
-        return parent::arrayIdToModel(
-            self::fetchIds()
-        );
+        return self::getQueryBuilder()
+            ->getModels()
+        ;
     }
 
     /**
@@ -120,18 +121,18 @@ class Permission extends Model
             return $perm_name;
         }
 
-        return self::get(
-            self::fetchIdFrom($perm_name, "name")
-        );
+        return self::getQueryBuilder()
+            ->find($perm_name, 'name')
+        ;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public static function getQueryBuilder()
     {
-        return new QueryBuilder("Permission", array(
-            'columns' => array(
-                'name' => 'name'
-            ),
-            'name' => 'name'
-        ));
+        return QueryBuilderFlex::createForModel(Permission::class)
+            ->setNameColumn('name')
+        ;
     }
 }

--- a/models/Permission.php
+++ b/models/Permission.php
@@ -122,7 +122,7 @@ class Permission extends Model implements NamedModel
         }
 
         return self::getQueryBuilder()
-            ->find($perm_name, 'name')
+            ->findModel($perm_name, 'name')
         ;
     }
 

--- a/models/Player.php
+++ b/models/Player.php
@@ -170,9 +170,9 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
 
     private $matchActivity;
 
-    /**
-     * The name of the database table used for queries
-     */
+    private $is_disabled;
+
+    const DELETED_COLUMN = 'is_deleted';
     const TABLE = "players";
 
     /**
@@ -193,9 +193,10 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
         $this->name = $player['username'];
         $this->alias = $player['alias'];
         $this->team = $player['team'];
-        $this->status = $player['status'];
         $this->avatar = $player['avatar'];
         $this->country = $player['country'];
+        $this->is_disabled = $player['is_disabled'];
+        $this->is_deleted = $player['is_deleted'];
 
         if (array_key_exists('activity', $player)) {
             $this->matchActivity = ($player['activity'] != null) ? $player['activity'] : 0.0;
@@ -1378,20 +1379,57 @@ class Player extends AvatarModel implements NamedModel, DuplexUrlInterface, EloI
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public static function getEagerColumnsList()
+    {
+        return [
+            'id',
+            'bzid',
+            'team',
+            'username',
+            'alias',
+            'avatar',
+            'country',
+            'is_disabled',
+            'is_deleted',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getLazyColumnsList()
+    {
+        return [
+            'email',
+            'verified',
+            'receives',
+            'confirm_code',
+            'outdated',
+            'description',
+            'theme',
+            'color_blind_enabled',
+            'timezone',
+            'joined',
+            'last_login',
+            'last_match',
+            'admin_notes',
+        ];
+    }
+
+    /**
      * Get a query builder for players
+     *
+     * @throws Exception
+     *
      * @return PlayerQueryBuilder
      */
     public static function getQueryBuilder()
     {
-        return new PlayerQueryBuilder('Player', array(
-            'columns' => array(
-                'name'     => 'username',
-                'team'     => 'team',
-                'outdated' => 'outdated',
-                'status'   => 'status',
-            ),
-            'name' => 'name',
-        ));
+        return PlayerQueryBuilder::createForModel(Player::class)
+            ->setNameColumn('username')
+        ;
     }
 
     /**

--- a/models/Visit.php
+++ b/models/Visit.php
@@ -89,17 +89,14 @@ class Visit extends Model
 
     /**
      * Get a query builder for players
-     * @return QueryBuilder
+     *
+     * @throws Exception
+     *
+     * @return QueryBuilderFlex
      */
     public static function getQueryBuilder()
     {
-        return new VisitQueryBuilder('Visit', array(
-            'columns' => array(
-                'ip' => 'ip',
-                'timestamp' => 'timestamp'
-            ),
-            'name' => 'name',
-        ));
+        return VisitQueryBuilder::createForModel(Visit::class);
     }
 
     /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -375,7 +375,7 @@ abstract class Controller
      *
      * @param string $type The model whose query builder we should get (null
      *                     to get the builder of the controller's model)
-     * @return QueryBuilder
+     * @return QueryBuilder|QueryBuilderFlex
      */
     public static function getQueryBuilder($type = null)
     {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -382,7 +382,7 @@ abstract class Controller
         $type = ($type) ?: static::getName();
 
         return $type::getQueryBuilder()
-            ->visibleTo(static::getMe(), static::getRequest()->get('showDeleted'));
+            ->visibleTo(static::getMe(), (bool)static::getRequest()->get('showDeleted'));
     }
 
      /**

--- a/src/Database.php
+++ b/src/Database.php
@@ -137,6 +137,9 @@ class Database
                 ];
             }
 
+            $config['charset'] = 'utf8';
+            $config['collation'] = 'utf8_unicode_ci';
+
             Service::setQueryBuilderConfig($config);
         }
 

--- a/src/Database.php
+++ b/src/Database.php
@@ -112,6 +112,14 @@ class Database
                     Service::getParameter('bzion.testing.password'),
                     Service::getParameter('bzion.testing.database')
                 );
+
+                $config = [
+                    'driver'    => 'mysql',
+                    'host'      => Service::getParameter('bzion.testing.host'),
+                    'database'  => Service::getParameter('bzion.testing.database'),
+                    'username'  => Service::getParameter('bzion.testing.username'),
+                    'password'  => Service::getParameter('bzion.testing.password'),
+                ];
             } else {
                 self::$Database = new self(
                     Service::getParameter('bzion.mysql.host'),
@@ -119,7 +127,17 @@ class Database
                     Service::getParameter('bzion.mysql.password'),
                     Service::getParameter('bzion.mysql.database')
                 );
+
+                $config = [
+                    'driver'    => 'mysql',
+                    'host'      => Service::getParameter('bzion.mysql.host'),
+                    'database'  => Service::getParameter('bzion.mysql.database'),
+                    'username'  => Service::getParameter('bzion.mysql.username'),
+                    'password'  => Service::getParameter('bzion.mysql.password'),
+                ];
             }
+
+            Service::setQueryBuilderConfig($config);
         }
 
         return self::$Database;

--- a/src/Debug/DatabaseQuery.php
+++ b/src/Debug/DatabaseQuery.php
@@ -72,7 +72,7 @@ class DatabaseQuery
      * @param string     $query  The MySQL query
      * @param array|null $params The query parameters
      */
-    public function __construct(&$query, &$params)
+    public function __construct($query, $params)
     {
         $this->query  = $query;
         $this->params = ($params !== false) ? array_values($params) : null;

--- a/src/Exception/DeletionDeniedException.php
+++ b/src/Exception/DeletionDeniedException.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Exception thrown when something is attempted to be deleted from the database but permission was denied.
+ */
+class DeletionDeniedException extends RuntimeException
+{
+
+}

--- a/src/Form/Creator/InvitationFormCreator.php
+++ b/src/Form/Creator/InvitationFormCreator.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace BZIon\Form\Creator;
+
+use BZIon\Event\Events;
+use BZIon\Event\TeamInviteEvent;
+use BZIon\Form\Constraint\NotBlankModel;
+use BZIon\Form\Type\AdvancedModelType;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * @property \Team $editing
+ */
+class InvitationFormCreator extends ModelFormCreator
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function build($builder)
+    {
+        $invitedPlayer = new AdvancedModelType(\Player::class, [
+            'constraints' => [
+                new NotBlankModel(),
+            ],
+            'label' => 'Invitation Recipient',
+            'required' => true,
+        ]);
+
+        $targetTeam = $builder
+            ->create('target_team', HiddenType::class, [
+                'data' => $this->editing->getId(),
+            ])
+            ->setDataLocked(true)
+        ;
+
+        $builder
+            ->add($targetTeam)
+            ->add('invited_player', $invitedPlayer)
+            ->add('message', TextareaType::class, [
+                'required' => false,
+            ])
+            ->add('cancel', ButtonType::class, [
+                'label' => 'Cancel',
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'Invite',
+                'attr' => [
+                    'class' => 'c-button--blue pattern pattern--upward-stripes'
+                ]
+            ])
+            ->addEventListener(FormEvents::POST_SUBMIT, [$this, 'checkPlayerEligibility'])
+        ;
+
+        return $builder;
+    }
+
+    public function checkPlayerEligibility(FormEvent $event)
+    {
+        $form = $event->getForm();
+
+        if ($form->has('invited_player')) {
+            $formElement = $form->get('invited_player');
+
+            /** @var \Player|null $proposedInvitee */
+            $proposedInvitee = $formElement->getData();
+
+            if ($proposedInvitee === null) {
+                $formElement->addError(new FormError('Invited player not found.'));
+                return;
+            }
+
+            if ($this->editing->isMember($proposedInvitee->getId())) {
+                $formElement->addError(new FormError('This player is already a member of that team.'));
+            }
+
+            if (\Invitation::playerHasInvitationToTeam($proposedInvitee->getId(), $this->editing->getId())) {
+                $formElement->addError(new FormError('This player already has an invitation to this team.'));
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enter($form)
+    {
+        $invite = \Invitation::sendInvite(
+            $form->get('invited_player')->getData(),
+            $form->get('target_team')->getData(),
+            $this->me->getId(),
+            $form->get('message')->getData()
+        );
+        \Service::getDispatcher()->dispatch(Events::TEAM_INVITE, new TeamInviteEvent($invite));
+
+        return $invite;
+    }
+}

--- a/src/Form/Creator/MapFormCreator.php
+++ b/src/Form/Creator/MapFormCreator.php
@@ -113,6 +113,13 @@ class MapFormCreator extends ModelFormCreator
                 'multiple' => false,
                 'label'    => 'Game Mode',
             ])
+            ->add('is_inactive', CheckboxType::class, [
+                'label' => 'Map is inactive',
+                'required' => false,
+                'attr' => [
+                    'data-help-message' => 'By checking this box, it means this map is no longer available on the official match servers via /maplist',
+                ],
+            ])
         ;
 
         if ($this->editing) {
@@ -144,6 +151,7 @@ class MapFormCreator extends ModelFormCreator
         $form->get('jumping')->setData($map->isJumpingEnabled());
         $form->get('ricochet')->setData($map->isRicochetEnabled());
         $form->get('game_mode')->setData($map->getGameMode());
+        $form->get('is_inactive')->setData($map->isInactive());
     }
 
     /**
@@ -164,6 +172,7 @@ class MapFormCreator extends ModelFormCreator
             ->setWorldSize($form->get('world_size')->getData())
             ->setRandomlyGenerated($form->get('randomly_generated')->getData())
             ->setGameMode($form->get('game_mode')->getData())
+            ->setInactive($form->get('is_inactive')->getData())
         ;
     }
 
@@ -183,6 +192,7 @@ class MapFormCreator extends ModelFormCreator
         $map->setJumpingEnabled($form->get('jumping')->getData());
         $map->setRicochetEnabled($form->get('ricochet')->getData());
         $map->setGameMode($form->get('game_mode')->getData());
+        $map->setInactive($form->get('is_inactive')->getData());
 
         if ($form->has('delete_avatar') && $form->get('delete_avatar')->isClicked()) {
             $map->resetAvatar();

--- a/src/Form/Creator/PageFormCreator.php
+++ b/src/Form/Creator/PageFormCreator.php
@@ -7,11 +7,17 @@
 
 namespace BZIon\Form\Creator;
 
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
  * Form creator for pages
+ *
+ * @property \Page $editing
  */
 class PageFormCreator extends ModelFormCreator
 {
@@ -20,55 +26,75 @@ class PageFormCreator extends ModelFormCreator
      */
     protected function build($builder)
     {
-        return $builder
-            ->add(
-                $builder->create('name', 'text', array(
-                    'constraints' => array(
-                        new NotBlank(), new Length(array(
-                            'max' => 32,
-                        )),
-                    ),
-                    'data' => $this->controller->data->get('name')
-                ))->setDataLocked(false)
-            )
-            ->add('content', 'textarea', array(
-                'constraints' => new NotBlank()
-            ))
-            ->add('status', 'choice', array(
-                'choices' => array(
-                    'live'     => 'Public',
-                    'revision' => 'Revision',
-                    'disabled' => 'Disabled',
-                ),
-                'description' => "'Revision' pages are accessible by all users but not listed in the menu, " .
-                    "while 'Disabled' pages cannot be accessed by players."
-            ))
-            ->add('enter', 'submit', [
+        $editingDraftOrCreatingNew = ($this->editing === null || $this->editing->isDraft());
+        $editingPublishedPage = ($this->editing !== null && !$this->editing->isDraft());
+
+        $builder
+            ->add('name', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Length([
+                        'max' => 32,
+                    ]),
+                ],
+            ])
+            ->add('content', TextareaType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('is_unlisted', CheckboxType::class, [
+                'label' => 'Unlisted Page',
+                'required' => false,
+                'attr' => [
+                    'data-help-message' => 'This page will not be listed on the footer of the website',
+                ],
+            ])
+            ->add('modify_draft', SubmitType::class, [
+                'attr' => [
+                    'class' => 'c-button--green pattern pattern--upward-stripes',
+                ],
+                'label' => $editingDraftOrCreatingNew ? 'Save Draft' : 'Unpublish Page',
+            ])
+            ->add('submit', SubmitType::class, [
                 'attr' => [
                     'class' => 'c-button--blue pattern pattern--downward-stripes',
                 ],
-            ]);
+                'label' => $editingPublishedPage ? 'Save Changes' : 'Publish Page',
+            ])
+        ;
+
+        return $builder;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param \Page $page
      */
     public function fill($form, $page)
     {
         $form->get('name')->setData($page->getName());
         $form->get('content')->setData($page->getContent());
-        $form->get('status')->setData($page->getStatus());
+        $form->get('is_unlisted')->setData($page->isUnlisted());
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param \Page $page
      */
     public function update($form, $page)
     {
-        $page->setName($form->get('name')->getData())
-             ->setContent($form->get('content')->getData())
-             ->setStatus($form->get('status')->getData())
-             ->updateEditTimestamp();
+        $saveDraft = $form->get('modify_draft');
+
+        $page
+            ->setName($form->get('name')->getData())
+            ->setContent($form->get('content')->getData())
+            ->setUnlisted($form->get('is_unlisted')->getData())
+            ->setDraft($saveDraft->isClicked())
+            ->updateEditTimestamp()
+        ;
     }
 
     /**
@@ -80,7 +106,8 @@ class PageFormCreator extends ModelFormCreator
             $form->get('name')->getData(),
             $form->get('content')->getData(),
             $this->me->getId(),
-            $form->get('status')->getData()
+            $form->get('modify_draft')->isClicked(),
+            $form->get('is_unlisted')->getData()
         );
     }
 }

--- a/src/Form/Creator/ProfileFormCreator.php
+++ b/src/Form/Creator/ProfileFormCreator.php
@@ -9,6 +9,7 @@ namespace BZIon\Form\Creator;
 
 use BZIon\Form\Type\ModelType;
 use BZIon\Form\Type\TimezoneType;
+use Country;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -65,6 +66,9 @@ class ProfileFormCreator extends ModelFormCreator
         $themeSlugs = array_column(\Service::getSiteThemes(), 'slug');
         $themes = array_combine($themeSlugs, $themeNames);
 
+        // Add all of our countries into the cache since flags are displayed
+        Country::getQueryBuilder()->addToCache();
+
         $builder
             ->add('description', TextareaType::class, array(
                 'constraints' => new Length(array('max' => 8000)),
@@ -80,7 +84,7 @@ class ProfileFormCreator extends ModelFormCreator
                 'required' => false
             ))
             ->add('delete_avatar', SubmitType::class)
-            ->add('country', new ModelType('Country'), array(
+            ->add('country', new ModelType(Country::class), array(
                 'constraints' => new NotBlank(),
                 'data'        => $this->editing->getCountry()
             ))

--- a/src/Form/Creator/ServerFormCreator.php
+++ b/src/Form/Creator/ServerFormCreator.php
@@ -9,6 +9,11 @@ namespace BZIon\Form\Creator;
 
 use BZIon\Form\Type\AdvancedModelType;
 use BZIon\Form\Type\ModelType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -17,40 +22,67 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 class ServerFormCreator extends ModelFormCreator
 {
+    const OFFICIAL_MATCH_SERVER = 'oms';
+    const OFFICIAL_REPLAY_SERVER = 'ors';
+    const PUBLIC_SERVER = 'ps';
+    const PUBLIC_REPLAY_SERVER = 'prs';
+
     /**
      * {@inheritdoc}
      */
     protected function build($builder)
     {
         return $builder
-            ->add('domain', 'text', array(
-                'constraints' => array(
-                    new NotBlank(), new Length(array(
+            ->add('domain', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Length([
                         'max' => 50,
-                    )),
-                ),
-            ))
+                    ]),
+                ],
+            ])
             ->add(
-                $builder->create('port', 'integer', array(
+                $builder->create('port', IntegerType::class, array(
                     'constraints' => new NotBlank(),
                     'data'        => 5154
-                ))->setDataLocked(false) // Don't lock the data so we can change
-                                         // the default value later if needed
+                ))->setDataLocked(false) // Don't lock the data so we can change the default value later if needed
             )
-            ->add('name', 'text', array(
-                'constraints' => array(
-                    new NotBlank(), new Length(array(
+            ->add('name', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Length([
                         'max' => 100,
-                    )),
-                ),
-            ))
-            ->add('country', new ModelType('Country'), array(
-                'constraints' => new NotBlank()
-            ))
-            ->add('owner', new AdvancedModelType('Player'), array(
-                'constraints' => new NotBlank()
-            ))
-            ->add('enter', 'submit', [
+                    ]),
+                ],
+            ])
+            ->add('country', new ModelType('Country'), [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('owner', new AdvancedModelType('Player'), [
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('server_type', ChoiceType::class, [
+                'choices' => [
+                    self::OFFICIAL_MATCH_SERVER  => 'Official Match Server',
+                    self::OFFICIAL_REPLAY_SERVER => 'Official Replay Server',
+                    self::PUBLIC_SERVER          => 'Public Server',
+                    self::PUBLIC_REPLAY_SERVER   => 'Public Replay Server',
+                ],
+                'required' => true,
+                'label' => 'Server Type',
+            ])
+            ->add('inactive', CheckboxType::class, [
+                'label' => 'Server Inactive',
+                'required' => false,
+                'attr' => [
+                    'data-help-message' => 'When checked, that means this server is no longer active in hosting',
+                ],
+            ])
+            ->add('enter', SubmitType::class, [
                 'attr' => [
                     'class' => 'c-button--blue pattern pattern--downward-stripes',
                 ],
@@ -60,6 +92,8 @@ class ServerFormCreator extends ModelFormCreator
 
     /**
      * {@inheritdoc}
+     *
+     * @param \Server $server
      */
     public function fill($form, $server)
     {
@@ -68,19 +102,47 @@ class ServerFormCreator extends ModelFormCreator
         $form->get('port')->setData($server->getPort());
         $form->get('country')->setData($server->getCountry());
         $form->get('owner')->setData($server->getOwner());
+        $form->get('inactive')->setData($server->isInactive());
+
+        $serverType = $form->get('server_type');
+
+        if ($server->isOfficialServer()) {
+            if ($server->isReplayServer()) {
+                $serverType->setData(self::OFFICIAL_REPLAY_SERVER);
+            }
+            else {
+                $serverType->setData(self::OFFICIAL_MATCH_SERVER);
+            }
+        }
+        else {
+            if ($server->isReplayServer()) {
+                $serverType->setData(self::PUBLIC_REPLAY_SERVER);
+            }
+            else {
+                $serverType->setData(self::PUBLIC_SERVER);
+            }
+        }
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param \Server $server
      */
     public function update($form, $server)
     {
-        $server->setName($form->get('name')->getData())
-               ->setDomain($form->get('domain')->getData())
-               ->setPort($form->get('port')->getData())
-               ->setCountry($form->get('country')->getData()->getId())
-               ->setOwner($form->get('owner')->getData()->getId())
-               ->forceUpdate();
+        $server
+            ->setName($form->get('name')->getData())
+            ->setDomain($form->get('domain')->getData())
+            ->setPort($form->get('port')->getData())
+            ->setCountry($form->get('country')->getData()->getId())
+            ->setOwner($form->get('owner')->getData()->getId())
+            ->setInactive($form->get('inactive')->getData())
+        ;
+
+        $this->updateServerType($server, $form->get('server_type')->getData());
+
+        $server->forceUpdate();
     }
 
     /**
@@ -88,12 +150,43 @@ class ServerFormCreator extends ModelFormCreator
      */
     public function enter($form)
     {
-        return \Server::addServer(
+        $server = \Server::addServer(
             $form->get('name')->getData(),
             $form->get('domain')->getData(),
             $form->get('port')->getData(),
             $form->get('country')->getData()->getId(),
             $form->get('owner')->getData()->getId()
         );
+
+        $server->setInactive($form->get('inactive')->getData());
+
+        $this->updateServerType($server, $form->get('server_type')->getData());
+
+        return $server;
+    }
+
+    private function updateServerType(\Server $server, $serverType)
+    {
+        switch ($serverType) {
+            case self::OFFICIAL_MATCH_SERVER:
+                $server->setOfficialServer(true);
+                $server->setReplayServer(false);
+                break;
+
+            case self::OFFICIAL_REPLAY_SERVER:
+                $server->setOfficialServer(true);
+                $server->setReplayServer(true);
+                break;
+
+            case self::PUBLIC_SERVER:
+                $server->setOfficialServer(false);
+                $server->setReplayServer(false);
+                break;
+
+            case self::PUBLIC_REPLAY_SERVER:
+                $server->setOfficialServer(false);
+                $server->setReplayServer(true);
+                break;
+        }
     }
 }

--- a/src/Form/Type/AdvancedModelType.php
+++ b/src/Form/Type/AdvancedModelType.php
@@ -118,8 +118,7 @@ class AdvancedModelType extends AbstractType
             ];
             $manualOptions = __::get($this->options, $type, []);
 
-            // @todo Replace array_merge_recursive_distinct() with __::merge() when it's available
-            $builder->add($type, TextType::class, $this->array_merge_recursive_distinct($defaultOptions, $manualOptions));
+            $builder->add($type, TextType::class, __::merge($defaultOptions, $manualOptions));
         }
 
         if ($this->multiple) {
@@ -201,23 +200,5 @@ class AdvancedModelType extends AbstractType
     public function getName()
     {
         return 'advanced_model';
-    }
-
-    /**
-     * @deprecated Will be replaced by __::merge()
-     */
-    private function array_merge_recursive_distinct(array &$array1, array &$array2)
-    {
-        $merged = $array1;
-
-        foreach ($array2 as $key => &$value) {
-            if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
-                $merged[$key] = $this->array_merge_recursive_distinct($merged[$key], $value);
-            } else {
-                $merged[$key] = $value;
-            }
-        }
-
-        return $merged;
     }
 }

--- a/src/Form/Type/ModelType.php
+++ b/src/Form/Type/ModelType.php
@@ -44,7 +44,7 @@ class ModelType extends AbstractType
      */
     public function __construct($type, $emptyElem = true, $modifier = null)
     {
-        $this->type = "$type";
+        $this->type = $type;
         $this->emptyElem = $emptyElem;
         $this->modifier = $modifier;
     }
@@ -123,7 +123,9 @@ class ModelType extends AbstractType
 
     private function getAll()
     {
-        $query    = \Controller::getQueryBuilder($this->type);
+        $query = \Controller::getQueryBuilder($this->type);
+        $query->active();
+
         $modifier = $this->modifier;
 
         if ($modifier) {

--- a/src/Model/AliasModel.php
+++ b/src/Model/AliasModel.php
@@ -50,7 +50,7 @@ abstract class AliasModel extends UrlModel implements NamedModel
     /**
      * Change the object's name
      *
-     * @return self
+     * @return static
      */
     public function setName($name)
     {

--- a/src/Model/BaseModel.php
+++ b/src/Model/BaseModel.php
@@ -361,7 +361,7 @@ abstract class BaseModel implements ModelInterface
     /**
      * Get the MySQL columns that will be loaded as soon as the model is created
      *
-     * @todo Make this protected
+     * @deprecated 0.10.2 Replaced by static::getEagerColumnsList() in 0.11.0
      *
      * @param string $prefix The prefix that'll be prefixed to column names
      *
@@ -379,6 +379,8 @@ abstract class BaseModel implements ModelInterface
      * This is done in order to reduce the time needed to load parameters that
      * will not be requested (e.g player activation codes or permissions)
      *
+     * @deprecated 0.10.2 Replaced by static::getLazyColumnsList() in 0.11.0
+     *
      * @return string|null The columns in a format readable by MySQL or null to
      *                     fetch no columns at all
      */
@@ -389,6 +391,8 @@ abstract class BaseModel implements ModelInterface
 
     /**
      * Get a formatted string with a comma separated column list with table/alias prefixes if necessary.
+     *
+     * @deprecated 0.10.2 This function has been removed and is no longer required with the new query builder
      *
      * @param string|null $prefix  The table name or SQL alias to be prepend to these columns
      * @param array       $columns The columns to format

--- a/src/Model/BaseModel.php
+++ b/src/Model/BaseModel.php
@@ -501,23 +501,30 @@ abstract class BaseModel implements ModelInterface
      * Load all the properties of the model that haven't been loaded yet
      *
      * @param  bool $force Whether to force a reload
-     * @return self
+     *
+     * @throws \Pecee\Pixie\Exception
+     * @throws Exception
+     *
+     * @return static
      */
     protected function lazyLoad($force = false)
     {
         if ((!$this->loaded || $force) && $this->valid) {
             $this->loaded = true;
 
-            $columns = $this->getLazyColumns();
+            $columns = static::getLazyColumnsList();
 
-            if ($columns !== null) {
-                $results = $this->db->query("SELECT $columns FROM {$this->table} WHERE id = ? LIMIT 1", array($this->id));
+            if (!empty($columns)) {
+                $results = static::getQueryBuilder()
+                    ->select($columns)
+                    ->find($this->getId())
+                ;
 
-                if (count($results) < 1) {
+                if (empty($results)) {
                     throw new Exception("The model has mysteriously disappeared");
                 }
 
-                $this->assignLazyResult($results[0]);
+                $this->assignLazyResult($results);
             } else {
                 $this->assignLazyResult(array());
             }

--- a/src/Model/BaseModel.php
+++ b/src/Model/BaseModel.php
@@ -52,8 +52,20 @@ abstract class BaseModel implements ModelInterface
 
     /**
      * The default status value for deletable models
+     *
+     * @deprecated 0.10.3 The `status` SET columns are deprecated. Using boolean columns is now the new standard.
      */
     const DEFAULT_STATUS = 'active';
+
+    /**
+     * The column name in the database that is used for marking a row as soft deleted.
+     */
+    const DELETED_COLUMN = null;
+
+    /**
+     * The value that's used in `self::DELETED_COLUMN` to mark something as soft deleted.
+     */
+    const DELETED_VALUE = true;
 
     /**
      * The name of the database table used for queries

--- a/src/Model/BaseModel.php
+++ b/src/Model/BaseModel.php
@@ -39,6 +39,12 @@ abstract class BaseModel implements ModelInterface
     protected $status;
 
     /**
+     * Whether or not this model has been soft deleted.
+     * @var bool
+     */
+    protected $is_deleted;
+
+    /**
      * The database variable used for queries
      * @var Database
      */
@@ -167,8 +173,17 @@ abstract class BaseModel implements ModelInterface
      */
     public function delete()
     {
-        $this->status = 'deleted';
-        $this->update('status', 'deleted');
+        if (static::DELETED_COLUMN === null) {
+            @trigger_error(sprintf('The %s class is using the deprecated `status` column and needs to be updated.', get_called_class()), E_USER_DEPRECATED);
+
+            $this->status = 'deleted';
+            $this->update('status', 'deleted');
+
+            return;
+        }
+
+        $this->is_deleted = true;
+        $this->update('is_deleted', true);
     }
 
     /**

--- a/src/Model/BaseModel.php
+++ b/src/Model/BaseModel.php
@@ -74,6 +74,11 @@ abstract class BaseModel implements ModelInterface
     const DELETED_VALUE = true;
 
     /**
+     * This model is handled directly by BZiON and is not editable by users.
+     */
+    const SYSTEM_MODEL = false;
+
+    /**
      * The name of the database table used for queries
      * You can use this constant in static methods as such:
      * static::TABLE

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -13,6 +13,12 @@
 abstract class Model extends CachedModel
 {
     /**
+     * Whether or not this model has been soft deleted.
+     * @var bool
+     */
+    protected $is_deleted;
+
+    /**
      * Generates a string with the object's type and ID
      */
     public function __toString()
@@ -27,7 +33,7 @@ abstract class Model extends CachedModel
      */
     public function isDeleted()
     {
-        if (!$this->isValid() || $this->getStatus() == 'deleted') {
+        if (!$this->isValid() || $this->is_deleted || $this->getStatus() == 'deleted') {
             return true;
         }
 
@@ -41,16 +47,26 @@ abstract class Model extends CachedModel
      */
     public function isActive()
     {
+        if (self::DELETED_COLUMN !== null) {
+            return (!$this->is_deleted);
+        }
+
+        @trigger_error('Update this model to use the DELETED_* constants instead of the "status" column.', E_USER_DEPRECATED);
+
         return in_array($this->getStatus(), $this->getActiveStatuses());
     }
 
     /**
      * Get the models's status
      *
+     * @deprecated 0.10.3 Use isDeleted() for checking for deleted models instead.
+     *
      * @return string
      */
     public function getStatus()
     {
+        @trigger_error('The "status" of models has been deprecated. Use isDeleted() for checking for deleted models.', E_USER_DEPRECATED);
+
         if (!isset($this->status)) {
             $this->status = static::DEFAULT_STATUS;
         }

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -41,7 +41,7 @@ abstract class Model extends CachedModel
      */
     public function isActive()
     {
-        if (self::DELETED_COLUMN !== null) {
+        if (static::DELETED_COLUMN !== null) {
             return (!$this->is_deleted);
         }
 

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -13,12 +13,6 @@
 abstract class Model extends CachedModel
 {
     /**
-     * Whether or not this model has been soft deleted.
-     * @var bool
-     */
-    protected $is_deleted;
-
-    /**
      * Generates a string with the object's type and ID
      */
     public function __toString()

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -219,6 +219,21 @@ abstract class Model extends CachedModel
     }
 
     /**
+     * Create a single model object from a database result
+     *
+     * @param array $result The MySQL row of the model
+     *
+     * @return static
+     */
+    public static function createFromDatabaseResult(&$result)
+    {
+        $model = new static($result['id'], $result);
+        $model->storeInCache();
+
+        return $model;
+    }
+
+    /**
      * Create model objects, given their MySQL entries
      *
      * @param  array $results The MySQL rows of the model
@@ -229,10 +244,7 @@ abstract class Model extends CachedModel
         $models = array();
 
         foreach ($results as $result) {
-            $model = new static($result['id'], $result);
-            $model->storeInCache();
-
-            $models[] = $model;
+            $models[] = self::createFromDatabaseResult($result);
         }
 
         return $models;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -45,7 +45,7 @@ abstract class Model extends CachedModel
             return (!$this->is_deleted);
         }
 
-        @trigger_error('Update this model to use the DELETED_* constants instead of the "status" column.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('Update the "%s" model to use the DELETED_* constants instead of the "status" column.', get_called_class()), E_USER_DEPRECATED);
 
         return in_array($this->getStatus(), $this->getActiveStatuses());
     }
@@ -59,7 +59,7 @@ abstract class Model extends CachedModel
      */
     public function getStatus()
     {
-        @trigger_error('The "status" of models has been deprecated. Use isDeleted() for checking for deleted models.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "status" of models has been deprecated. Use %s::isDeleted() for checking for deleted models.', get_called_class()), E_USER_DEPRECATED);
 
         if (!isset($this->status)) {
             $this->status = static::DEFAULT_STATUS;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -53,7 +53,7 @@ abstract class Model extends CachedModel
     /**
      * Get the models's status
      *
-     * @deprecated 0.10.3 Use isDeleted() for checking for deleted models instead.
+     * @deprecated 0.11.0 Use isDeleted() for checking for deleted models instead.
      *
      * @return string
      */

--- a/src/QueryBuilder/MatchActivityQueryBuilder.php
+++ b/src/QueryBuilder/MatchActivityQueryBuilder.php
@@ -1,35 +1,57 @@
 <?php
 
-/**
- * @property BaseModel $type
- */
-class MatchActivityQueryBuilder extends QueryBuilder
-{
-    protected function includeMatchActivity($selectColumns, $leftJoinOn, $useMatchParticipationTable = false)
-    {
-        $type = $this->type;
-        $columns = $type::getEagerColumns($this->getFromAlias());
+use Pecee\Pixie\QueryBuilder\JoinBuilder;
 
-        $this->columns['activity'] = 'activity';
-        $this->extraColumns = 'SUM(m2.activity) AS activity';
-        $this->extras .= '
-          LEFT JOIN
-            (SELECT
-              m.id,'
-              . implode(',', $selectColumns) . ',
-              TIMESTAMPDIFF(SECOND, timestamp, NOW()) / 86400 AS days_passed,
-              (0.0116687059537612 * (POW((45 - LEAST((SELECT days_passed), 45)), (1/6)) + ATAN(31 - (SELECT days_passed)) / 2)) AS activity
-            FROM
-              matches m' .
-            ($useMatchParticipationTable ? ' INNER JOIN match_participation mp ON m.id = mp.match_id ' : '')
-            . '
-            WHERE
-              DATEDIFF(NOW(), timestamp) <= 45
-            ORDER BY
-              timestamp DESC) m2 ON ' . $leftJoinOn
+abstract class MatchActivityQueryBuilder extends QueryBuilderFlex
+{
+    /**
+     * @throws \Pecee\Pixie\Exception
+     * @throws Exception
+     *
+     * @return static
+     */
+    protected function getMatchActivityWorthQuery()
+    {
+        $qb = self::createBuilder();
+
+        // The subquery to calculate each match's worth towards activity if it has occurred less than 45 days ago.
+        //   - 86400 is in seconds; i.e. 24 hours
+        //   - 0.0116687059537612 is a magic number
+        $matchActivityWorthQuery = $qb->table('matches')->alias('m');
+        $matchActivityWorthQuery
+            ->select([
+                'm.id',
+                $qb->raw('TIMESTAMPDIFF(SECOND, `m`.`timestamp`, NOW()) / 86400 AS days_passed'),
+                $qb->raw('(0.0116687059537612 * (POW((45 - LEAST((SELECT days_passed), 45)), (1/6)) + ATAN(31 - (SELECT days_passed)) / 2)) AS activity'),
+            ])
+            ->where($qb->raw('DATEDIFF(NOW(), `m`.`timestamp`) <= 45'))
+            ->orderBy('m.timestamp', 'DESC')
         ;
 
-        $this->groupQuery = 'GROUP BY ' . $columns;
+        return $matchActivityWorthQuery;
+    }
+
+    /**
+     * @throws \Pecee\Pixie\Exception
+     * @throws Exception
+     */
+    protected function buildMatchActivity(QueryBuilderFlex $subQuery, JoinBuilder $joinBuilder)
+    {
+        $qb = self::createBuilder();
+        $type = $this->modelType;
+
+        $this
+            ->select(
+                $qb->raw('SUM(m2.activity) AS activity')
+            )
+            ->leftJoin(
+                $qb->subQuery($subQuery, 'm2'),
+                function (&$table) use ($joinBuilder) {
+                    $table = $joinBuilder;
+                }
+            )
+            ->groupBy($type::getEagerColumnsList())
+        ;
 
         return $this;
     }

--- a/src/QueryBuilder/PlayerQueryBuilder.php
+++ b/src/QueryBuilder/PlayerQueryBuilder.php
@@ -1,13 +1,28 @@
 <?php
 
+use Pecee\Pixie\QueryBuilder\JoinBuilder;
+
 class PlayerQueryBuilder extends MatchActivityQueryBuilder
 {
+    /**
+     * @throws \Pecee\Pixie\Exception
+     * @throws Exception
+     */
     public function withMatchActivity()
     {
-        return $this->includeMatchActivity(
-            ['mp.user_id'],
-            'players.id = m2.user_id',
-            true
-        );
+        $subQuery = $this->getMatchActivityWorthQuery();
+        $subQuery
+            ->select([
+                'match_participation.user_id'
+            ])
+            ->innerJoin('match_participation', 'm.id', '=', 'match_participation.match_id')
+        ;
+
+        $join = new JoinBuilder();
+        $join
+            ->on('players.id', '=', 'm2.user_id')
+        ;
+
+        return $this->buildMatchActivity($subQuery, $join);
     }
 }

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -241,7 +241,7 @@ class QueryBuilderFlex extends QueryBuilderHandler
      *
      * @return array
      */
-    public function getModels($fastFetch = false)
+    public function getModels($fastFetch = true)
     {
         /** @var Model $type */
         $type = $this->modelType;

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -115,6 +115,19 @@ class QueryBuilderFlex extends QueryBuilderHandler
     }
 
     /**
+     * An alias for QueryBuilder::getModels(), with fast fetching on by default and no return of results.
+     *
+     * @param  bool $fastFetch Whether to perform one query to load all the model data instead of fetching them one by
+     *              one
+     *
+     * @return void
+     */
+    public function addToCache($fastFetch = true)
+    {
+        $this->getModels($fastFetch);
+    }
+
+    /**
      * Get the amount of pages this query would have.
      *
      * @return int

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -67,6 +67,17 @@ class QueryBuilderFlex extends QueryBuilderHandler
     /**
      * {@inheritdoc}
      */
+    public function __construct(\Pixie\Connection $connection = null)
+    {
+        parent::__construct($connection);
+
+        $this->setFetchMode(PDO::FETCH_ASSOC);
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
     public function limit($limit)
     {
         $this->resultsPerPage = $limit;
@@ -168,7 +179,6 @@ class QueryBuilderFlex extends QueryBuilderHandler
         $columns = ($fastFetch) ? $type::getEagerColumns() : ['*'];
 
         $this->select($columns);
-        $this->setFetchMode(PDO::FETCH_ASSOC);
 
         /** @var array $results */
         $results = $this->get();

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -99,7 +99,15 @@ class QueryBuilderFlex extends QueryBuilderHandler
      */
     public function get(): array
     {
-        return parent::get();
+        $queryObject = $this->getQuery();
+        $debug = new DatabaseQuery($queryObject->getSql(), $queryObject->getBindings());
+
+        /** @var array $results */
+        $results = parent::get();
+
+        $debug->finish($results);
+
+        return $results;
     }
 
     /**
@@ -272,14 +280,7 @@ class QueryBuilderFlex extends QueryBuilderHandler
     {
         $this->select($columns);
 
-        $queryObject = $this->getQuery();
-        $debug = new DatabaseQuery($queryObject->getSql(), $queryObject->getBindings());
-
-        $results = $this->get();
-
-        $debug->finish($results);
-
-        return $results;
+        return $this->get();
     }
 
     /**
@@ -307,13 +308,7 @@ class QueryBuilderFlex extends QueryBuilderHandler
 
         $this->select($modelColumnsToSelect);
 
-        $queryObject = $this->getQuery();
-        $debug = new DatabaseQuery($queryObject->getSql(), $queryObject->getBindings());
-
-        /** @var array $results */
         $results = $this->get();
-
-        $debug->finish($results);
 
         if ($fastFetch) {
             return $type::createFromDatabaseResults($results);
@@ -338,13 +333,7 @@ class QueryBuilderFlex extends QueryBuilderHandler
 
         $this->select(['id', $this->modelNameColumn]);
 
-        $queryObject = $this->getQuery();
-        $debug = new DatabaseQuery($queryObject->getSql(), $queryObject->getBindings());
-
-        /** @var array $results */
         $results = $this->get();
-
-        $debug->finish($results);
 
         return array_column($results, $this->modelNameColumn, 'id');
     }

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -119,6 +119,8 @@ class QueryBuilderFlex extends QueryBuilderHandler
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function limit($limit): IQueryBuilderHandler
     {
@@ -132,8 +134,12 @@ class QueryBuilderFlex extends QueryBuilderHandler
      */
     protected function whereHandler($key, string $operator = null, $value = null, $joiner = 'AND'): IQueryBuilderHandler
     {
+        // For certain type of objects, we convert them into something the query builder can handle correctly
         if ($value instanceof BaseModel) {
             $value = $value->getId();
+        }
+        elseif ($value instanceof DateTime) {
+            $value = (string)$value;
         }
 
         return parent::whereHandler($key, $operator, $value, $joiner);

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -12,6 +12,9 @@ use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
  */
 class QueryBuilderFlex extends QueryBuilderHandler
 {
+    /** @var array An array of values that'll be injected into returned database results */
+    protected $injectedValues = [];
+
     /** @var string The column name of the column dedicated to storing the name of the model */
     protected $modelNameColumn;
 
@@ -106,6 +109,10 @@ class QueryBuilderFlex extends QueryBuilderHandler
         $results = parent::get();
 
         $debug->finish($results);
+
+        foreach ($results as &$result) {
+            $result = array_merge($this->injectedValues, $result);
+        }
 
         return $results;
     }
@@ -336,6 +343,23 @@ class QueryBuilderFlex extends QueryBuilderHandler
         $results = $this->get();
 
         return array_column($results, $this->modelNameColumn, 'id');
+    }
+
+    /**
+     * Inject variables into the returned database results.
+     *
+     * These values will be merged in with values returned from database results. Database results will override any
+     * injected values.
+     *
+     * @param array $injection
+     *
+     * @return QueryBuilderFlex
+     */
+    public function injectResultValues(array $injection): QueryBuilderFlex
+    {
+        $this->injectedValues = $injection;
+
+        return $this;
     }
 
     /**

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -114,6 +114,13 @@ class QueryBuilderFlex extends QueryBuilderHandler
     public function active()
     {
         $type = $this->modelType;
+
+        // Since it's a system model, values are always handled by BZiON core meaning there will always only be "active"
+        // values in the database.
+        if ($type::SYSTEM_MODEL) {
+            return $this;
+        }
+
         $column = $type::DELETED_COLUMN;
 
         if ($column === null) {

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -1,0 +1,233 @@
+<?php
+
+use Pixie\QueryBuilder\QueryBuilderHandler;
+
+/**
+ * @since 0.10.3
+ */
+class QueryBuilderFlex extends QueryBuilderHandler
+{
+    /** @var Model|string The FQN of the model object this QueryBuilder instance is for */
+    private $modelType = null;
+
+    /** @var int The amount of results per page with regards to result pagination */
+    private $resultsPerPage;
+
+    //
+    // Factories
+    //
+
+    /**
+     * Create a QueryBuilder instance for a specific table.
+     *
+     * @param  string $tableName
+     *
+     * @throws Exception If there is no database connection configured.
+     *
+     * @return QueryBuilderFlex
+     */
+    public static function createForTable($tableName)
+    {
+        Database::getInstance();
+
+        $connection = Service::getQueryBuilderConnection();
+        $qbBase = new QueryBuilderFlex($connection);
+
+        $queryBuilder = $qbBase->table($tableName);
+
+        return $queryBuilder;
+    }
+
+    /**
+     * Creeate a QueryBuilder instance to work with a Model.
+     *
+     * @param  string $modelType The FQN for the model that
+     *
+     * @throws Exception If there is no database connection configured.
+     *
+     * @return QueryBuilderFlex
+     */
+    public static function createForModel($modelType)
+    {
+        Database::getInstance();
+
+        $connection = Service::getQueryBuilderConnection();
+        $qbBase = new QueryBuilderFlex($connection);
+
+        $queryBuilder = $qbBase->table(constant("$modelType::TABLE"));
+        $queryBuilder->setModelType($modelType);
+
+        return $queryBuilder;
+    }
+
+    //
+    // Overridden QueryBuilder Functions
+    //
+
+    /**
+     * {@inheritdoc}
+     */
+    public function limit($limit)
+    {
+        $this->resultsPerPage = $limit;
+
+        return parent::limit($limit);
+    }
+
+    //
+    // QueryBuilderFlex unique functions
+    //
+
+    /**
+     * Request that only non-deleted Models should be returned.
+     *
+     * @return static
+     */
+    public function active()
+    {
+        $type = $this->modelType;
+        $column = $type::DELETED_COLUMN;
+
+        if ($column === null) {
+            @trigger_error(
+                'The use of the status column is deprecated. Update this model to use the DELETED_* constants.',
+                E_USER_DEPRECATED
+            );
+
+            return $this->whereIn('status', $type::getActiveStatuses());
+        }
+
+        return $this->whereNot($column, '=', $type::DELETED_VALUE);
+    }
+
+    /**
+     * Get the amount of pages this query would have.
+     *
+     * @return int
+     */
+    public function countPages()
+    {
+        return (int)ceil($this->count() / $this->resultsPerPage);
+    }
+
+    /**
+     * Request that a specific model is not returned.
+     *
+     * @param  Model|int $model The ID or model you don't want to get
+     *
+     * @return static
+     */
+    public function except($model)
+    {
+        if ($model instanceof Model) {
+            $model = $model->getId();
+        }
+
+        $this->whereNot('id', '=', $model);
+
+        return $this;
+    }
+
+    /**
+     * Only show results from a specific page.
+     *
+     * This method will automatically take care of the calculations for a correct OFFSET.
+     *
+     * @param  int|null $page The page number (or null to show all pages - counting starts from 0)
+     *
+     * @return static
+     */
+    public function fromPage($page)
+    {
+        if ($page === null) {
+            $this->offset($page);
+
+            return $this;
+        }
+
+        $page = intval($page);
+        $page = ($page <= 0) ? 1 : $page;
+
+        $this->offset((min($page, $this->countPages()) - 1) * $this->resultsPerPage);
+
+        return $this;
+    }
+
+    /**
+     * Perform the query and get the results as Models.
+     *
+     * @param  bool $fastFetch Whether to perform one query to load all the model data instead of fetching them one by
+     *                         one (ignores cache)
+     *
+     * @return array
+     */
+    public function getModels($fastFetch = false)
+    {
+        /** @var Model $type */
+        $type = $this->modelType;
+        $columns = ($fastFetch) ? $type::getEagerColumns() : ['*'];
+
+        $this->select($columns);
+        $this->setFetchMode(PDO::FETCH_ASSOC);
+
+        /** @var array $results */
+        $results = $this->get();
+
+        if ($fastFetch) {
+            return $type::createFromDatabaseResults($results);
+        }
+
+        return $type::arrayIdToModel(array_column($results, 'id'));
+    }
+
+    /**
+     * Set the model this QueryBuilder will be working this.
+     *
+     * This information is used for automatically retrieving table names, eager columns, and lazy columns for these
+     * models.
+     *
+     * @param  string $modelType The FQN of the model this QueryBuilder will be working with
+     *
+     * @return $this
+     */
+    public function setModelType($modelType)
+    {
+        $this->modelType = $modelType;
+
+        return $this;
+    }
+
+    /**
+     * Make sure that Models invisible to a player are not returned.
+     *
+     * Note that this method does not take PermissionModel::canBeSeenBy() into
+     * consideration for performance purposes, so you will have to override this
+     * in your query builder if necessary.
+     *
+     * @param  Player $player      The player in question
+     * @param  bool   $showDeleted Use false to hide deleted models even from admins
+     *
+     * @return static
+     */
+    public function visibleTo(Player $player, $showDeleted = false)
+    {
+        $type = $this->modelType;
+
+        if (is_subclass_of($this->modelType, PermissionModel::class) &&
+            $player->hasPermission(constant("$type::EDIT_PERMISSION"))
+        ) {
+            // The player is an admin who can see the hidden models
+            if (!$showDeleted) {
+                $col = constant("$type::DELETED_COLUMN");
+
+                if ($col !== null) {
+                    $this->whereNot($col, '=', constant("$type::DELETED_VALUE"));
+                }
+            }
+        } else {
+            return $this->active();
+        }
+
+        return $this;
+    }
+}

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -237,6 +237,7 @@ class QueryBuilderFlex extends QueryBuilderHandler
     /**
      * Perform the query and get back the results in an array of names.
      *
+     * @throws \Pixie\Exception
      * @throws UnexpectedValueException When no name column has been specified
      *
      * @return string[] An array of the type $id => $name
@@ -249,8 +250,13 @@ class QueryBuilderFlex extends QueryBuilderHandler
 
         $this->select(['id', $this->modelNameColumn]);
 
+        $queryObject = $this->getQuery();
+        $debug = new DatabaseQuery($queryObject->getSql(), $queryObject->getBindings());
+
         /** @var array $results */
         $results = $this->get();
+
+        $debug->finish($results);
 
         return array_column($results, $this->modelNameColumn, 'id');
     }

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -1,5 +1,6 @@
 <?php
 
+use BZIon\Debug\DatabaseQuery;
 use Pixie\QueryBuilder\QueryBuilderHandler;
 
 /**
@@ -186,6 +187,8 @@ class QueryBuilderFlex extends QueryBuilderHandler
      * @param  bool $fastFetch Whether to perform one query to load all the model data instead of fetching them one by
      *                         one (ignores cache)
      *
+     * @throws \Pixie\Exception
+     *
      * @return array
      */
     public function getModels($fastFetch = false)
@@ -196,8 +199,13 @@ class QueryBuilderFlex extends QueryBuilderHandler
 
         $this->select($columns);
 
+        $queryObject = $this->getQuery();
+        $debug = new DatabaseQuery($queryObject->getSql(), $queryObject->getBindings());
+
         /** @var array $results */
         $results = $this->get();
+
+        $debug->finish($results);
 
         if ($fastFetch) {
             return $type::createFromDatabaseResults($results);

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -37,7 +37,7 @@ class QueryBuilderFlex extends QueryBuilderHandler
         Database::getInstance();
 
         $connection = Service::getQueryBuilderConnection();
-        $qbBase = new QueryBuilderFlex($connection);
+        $qbBase = new static($connection);
 
         $queryBuilder = $qbBase->table($tableName);
 
@@ -58,7 +58,7 @@ class QueryBuilderFlex extends QueryBuilderHandler
         Database::getInstance();
 
         $connection = Service::getQueryBuilderConnection();
-        $qbBase = new QueryBuilderFlex($connection);
+        $qbBase = new static($connection);
 
         $queryBuilder = $qbBase->table(constant("$modelType::TABLE"));
         $queryBuilder->setModelType($modelType);

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -185,6 +185,28 @@ class QueryBuilderFlex extends QueryBuilderHandler
     }
 
     /**
+     * Find the first matching model in the database or return an invalid model.
+     *
+     * @param mixed  $value      The value to search for
+     * @param string $columnName The column name we'll be checking
+     *
+     * @return Model
+     */
+    public function findModel($value, $columnName = 'id')
+    {
+        $type = $this->modelType;
+
+        /** @var array $result */
+        $result = parent::find($value, $columnName);
+
+        if ($result === null) {
+            return $type::get(0);
+        }
+
+        return $type::createFromDatabaseResult($result);
+    }
+
+    /**
      * Only show results from a specific page.
      *
      * This method will automatically take care of the calculations for a correct OFFSET.

--- a/src/QueryBuilder/QueryBuilderFlex.php
+++ b/src/QueryBuilder/QueryBuilderFlex.php
@@ -80,7 +80,6 @@ class QueryBuilderFlex extends QueryBuilderHandler
         $this->setFetchMode(PDO::FETCH_ASSOC);
     }
 
-
     /**
      * {@inheritdoc}
      */
@@ -89,6 +88,18 @@ class QueryBuilderFlex extends QueryBuilderHandler
         $this->resultsPerPage = $limit;
 
         return parent::limit($limit);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function whereHandler($key, $operator = null, $value = null, $joiner = 'AND')
+    {
+        if ($value instanceof BaseModel) {
+            $value = $value->getId();
+        }
+
+        return parent::whereHandler($key, $operator, $value, $joiner);
     }
 
     //

--- a/src/QueryBuilder/TeamQueryBuilder.php
+++ b/src/QueryBuilder/TeamQueryBuilder.php
@@ -1,12 +1,31 @@
 <?php
 
+use Pecee\Pixie\QueryBuilder\JoinBuilder;
+
 class TeamQueryBuilder extends MatchActivityQueryBuilder
 {
+    /**
+     * @throws \Pecee\Pixie\Exception
+     * @throws Exception
+     *
+     * @return $this
+     */
     public function withMatchActivity()
     {
-        return $this->includeMatchActivity(
-            ['m.team_a', 'm.team_b'],
-            'teams.id = m2.team_a OR teams.id = m2.team_b'
-        );
+        $subQuery = $this->getMatchActivityWorthQuery();
+        $subQuery
+            ->select([
+                'm.team_a',
+                'm.team_b',
+            ])
+        ;
+
+        $join = new JoinBuilder();
+        $join
+            ->on('teams.id', '=', 'm2.team_a')
+            ->orOn('teams.id', '=', 'm2.team_b')
+        ;
+
+        return $this->buildMatchActivity($subQuery, $join);
     }
 }

--- a/src/QueryBuilder/VisitQueryBuilder.php
+++ b/src/QueryBuilder/VisitQueryBuilder.php
@@ -12,21 +12,22 @@
  *
  * @package    BZiON\Models\QueryBuilder
  */
-class VisitQueryBuilder extends QueryBuilder
+class VisitQueryBuilder extends QueryBuilderFlex
 {
     /**
      * Search for a visit from the given IP or Host
      *
      * @param  string $query An IP or host to search
-     * @return self
+     *
+     * @return static
      */
     public function search($query)
     {
-        $this->whereConditions[] = "(ip LIKE CONCAT('%', ?, '%') OR host LIKE CONCAT('%', ?, '%'))";
-
-        $this->parameters[] = $query;
-        $this->parameters[] = $query;
-//        $this->parameters[] = $query;
+        $this->where(function ($qb) use ($query) {
+            /** @var static $qb */
+            $qb->where('ip', 'LIKE', "%$query%");
+            $qb->orWhere('host', 'LIKE', "%$query%");
+        });
 
         return $this;
     }

--- a/src/Service.php
+++ b/src/Service.php
@@ -7,6 +7,8 @@
  */
 
 use BZIon\Cache\ModelCache;
+use Pixie\Connection;
+use Pixie\QueryBuilder\QueryBuilderHandler;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormFactory;
@@ -55,6 +57,23 @@ abstract class Service
      * @var AppKernel
      */
     private static $kernel;
+
+    private static $qbConnection;
+    private static $qbConfig;
+
+    public static function setQueryBuilderConfig(array $config)
+    {
+        self::$qbConfig = $config;
+    }
+
+    public static function getQueryBuilderConnection()
+    {
+        if (!self::$qbConnection) {
+            self::$qbConnection = new Connection('mysql', self::$qbConfig);
+        }
+
+        return self::$qbConnection;
+    }
 
     /**
      * @param Request $request

--- a/src/Service.php
+++ b/src/Service.php
@@ -7,8 +7,7 @@
  */
 
 use BZIon\Cache\ModelCache;
-use Pixie\Connection;
-use Pixie\QueryBuilder\QueryBuilderHandler;
+use Pecee\Pixie\Connection;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormFactory;

--- a/src/Twig/AppGlobal.php
+++ b/src/Twig/AppGlobal.php
@@ -191,13 +191,17 @@ class AppGlobal
     /**
      * Get a list of visible pages
      *
+     * @throws \Pixie\Exception
+     *
      * @return \Page[]
      */
     public function getPages()
     {
         return \Page::getQueryBuilder()
-            ->where('status')->equals('live')
-            ->getModels($fast = true);
+            ->active()
+            ->whereNot('is_unlisted', '=', true)
+            ->getModels($fast = true)
+        ;
     }
 
     /**

--- a/tests/ModelTests/MatchEloTest.php
+++ b/tests/ModelTests/MatchEloTest.php
@@ -6,27 +6,6 @@ class MatchEloTest extends TestCase
     const TEAM_WIN = 1;
     const TEAM_DRAW = 2;
 
-    /** @var \Faker\Generator */
-    private $faker;
-    private $createdModels = [];
-
-    protected function setUp()
-    {
-        $this->connectToDatabase();
-
-        $this->faker = Faker\Factory::create();
-    }
-
-    public function tearDown()
-    {
-        foreach ($this->createdModels as $model)
-        {
-            $this->wipe($model);
-        }
-
-        parent::tearDown();
-    }
-
     //
     // Yes, we need to test our own helper function in our tests
     //

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,10 @@ use Symfony\Bundle\FrameworkBundle\Client;
 
 abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
+    /** @var \Faker\Generator */
+    protected $faker;
+    protected $createdModels = [];
+
     /**
      * The BZID of the last player created, used to prevent conflicts when creating new players
      * @var int
@@ -200,11 +204,22 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         }
     }
 
+    protected function setUp()
+    {
+        self::connectToDatabase();
+
+        $this->faker = Faker\Factory::create();
+    }
+
     /**
      * Clean-up all the database entries added during the test
      */
     public function tearDown()
     {
+        foreach ($this->createdModels as $model) {
+            $this->wipe($model);
+        }
+
         foreach ($this->playersCreated as $id) {
             self::wipe(Player::get($id));
         }

--- a/views/Invitation/invite.html.twig
+++ b/views/Invitation/invite.html.twig
@@ -1,0 +1,35 @@
+{% extends 'layout.html.twig' %}
+
+{% block title %}Inviting {{ player.name }} to {{ team.name }}{% endblock %}
+
+{% block pageTitle %}
+    <h1>Invitation to "{{ team.name }}"</h1>
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+                <p>Are you sure you would like to invite <strong>{{ player.name }}</strong> to <strong>{{ team.name }}</strong>?</p>
+
+                {{ form_start(form) }}
+                    {{ form_row(form.invited_player, { attr: { class: 'mb3' } }) }}
+                    {{ form_row(form.message, { attr: { class: 'mb3' } }) }}
+
+                    <div class="row">
+                        <div class="col-xs-6">
+                            {{ form_row(form.submit) }}
+                        </div>
+                        <div class="col-xs-6 text-right">
+                            {{ form_row(form.cancel) }}
+                        </div>
+                    </div>
+
+                    <div>
+                        {{ form_rest(form) }}
+                    </div>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/views/Map/form.html.twig
+++ b/views/Map/form.html.twig
@@ -32,18 +32,11 @@
                     </div>
                 </section>
 
-                <section class="row">
-                    <div class="col-md-3 text-center-md">
-                        {{ form_row(form.jumping, { 'container_attr': { 'class': 'mb3' } }) }}
-                    </div>
-
-                    <div class="col-md-3 text-center-md">
-                        {{ form_row(form.ricochet, { 'container_attr': { 'class': 'mb3' } }) }}
-                    </div>
-
-                    <div class="col-md-3 text-center-md">
-                        {{ form_row(form.randomly_generated, { 'container_attr': { 'class': 'mb3' } }) }}
-                    </div>
+                <section>
+                    {{ form_row(form.jumping, { 'container_attr': { 'class': 'c-form__checkbox--horizontal mb3' } }) }}
+                    {{ form_row(form.ricochet, { 'container_attr': { 'class': 'c-form__checkbox--horizontal mb3' } }) }}
+                    {{ form_row(form.randomly_generated, { 'container_attr': { 'class': 'c-form__checkbox--horizontal mb3' } }) }}
+                    {{ form_row(form.is_inactive, { 'container_attr': { 'class': 'c-form__checkbox--horizontal mb3' } }) }}
                 </section>
 
                 <div>

--- a/views/News/article.html.twig
+++ b/views/News/article.html.twig
@@ -1,7 +1,7 @@
 <article class="{{ class | default('') }}">
     <header>
         <h1>
-            {% if (article.status == "draft") %}
+            {% if article.draft %}
                 [Draft]
             {% endif %}
             {{ link_to(article) }}

--- a/views/News/form.html.twig
+++ b/views/News/form.html.twig
@@ -15,9 +15,24 @@
 
             <aside class="col-md-3">
                 {{ form_row(form.category, { 'container_attr': { 'class': 'mb3' } }) }}
-                {{ form_row(form.status,   { 'container_attr': { 'class': 'mb3' } }) }}
             </aside>
         </section>
+
+        <div class="row">
+            <div class="col-md-9">
+                <div class="row">
+                    <div class="col-xs-6">
+                        {{ form_row(form.publish) }}
+                    </div>
+
+                    {% if form.save_draft is defined %}
+                        <div class="col-xs-6 text-right">
+                            {{ form_row(form.save_draft) }}
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
 
         <div>
             {{ form_rest(form) }}

--- a/views/Page/form.html.twig
+++ b/views/Page/form.html.twig
@@ -5,20 +5,35 @@
         {{ form_errors(form) }}
 
         <div class="row">
-            <div class="col-md-8 mb3">
-                {{ form_row(form.name) }}
-            </div>
-            <div class="col-md-4 mb3">
-                {{ form_row(form.status) }}
-            </div>
-        </div>
+            <div class="col-md-9">
+                {{ form_row(form.name, { container_attr: { class: 'mb3' } }) }}
 
-        <div class="mb3">
-            {{ md_editor(form.content, {
-                data: {
-                    sanitize: "false"
-                }
-            }) }}
+                <div class="mb3">
+                    {{ md_editor(form.content, {
+                        data: {
+                            sanitize: "false"
+                        }
+                    }) }}
+                </div>
+
+                <div class="row">
+                    <div class="col-sm-6">
+                        {{ form_row(form.submit) }}
+                    </div>
+
+                    <div class="col-sm-6 text-right">
+                        {{ form_row(form.modify_draft) }}
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-3 py3-md">
+                {{ form_row(form.is_unlisted, {
+                    container_attr: {
+                        class: 'c-form__checkbox--horizontal mb3'
+                    }
+                }) }}
+            </div>
         </div>
 
         <div>

--- a/views/Page/show.html.twig
+++ b/views/Page/show.html.twig
@@ -22,7 +22,10 @@
 {% block title %}{{ page.name }}{% endblock %}
 
 {% block pageTitle %}
-    <h1>{{ page.name }}</h1>
+    <h1>
+        {% if page.draft %}[Draft]{% endif %}
+        {{ page.name }}
+    </h1>
 {% endblock %}
 
 {% block content %}

--- a/views/Server/form.html.twig
+++ b/views/Server/form.html.twig
@@ -19,6 +19,16 @@
             </div>
         </div>
 
+        <div class="row">
+            <div class="col-md-8 mb3">
+                {{ form_row(form.server_type) }}
+            </div>
+        </div>
+
+        <div>
+            {{ form_row(form.inactive, { container_attr: { class: 'c-form__checkbox--horizontal' } }) }}
+        </div>
+
         <div>
             {{ form_rest(form) }}
         </div>


### PR DESCRIPTION
~~Shame on me for deciding to sneak in such a *huge* change to BZiON's core in
 a planned point release... 😅  BUT [Deeeeeeeeploy Jenkins!](https://twitter.com/starsandrobots/status/954549424230866944)~~

_This PR has been reassigned to a 0.11.0 release_

This PR is dedicated to the restructuring of model statuses in the database and introducing a new query builder, powered by [Pixie](https://github.com/usmanhalalit/pixie).

- In order to allow for both query builders to coexist, the Pixie powered version has been dubbed `QueryBuilderFlex`.
  - This class name is subject to change.
- The practice of using `status` columns for models has been deprecated.
  - Due to [SET columns in MySQL being a bad idea](http://komlenic.com/244/8-reasons-why-mysqls-enum-data-type-is-evil/), models will be making use of boolean columns for model states (e.g. `is_deleted`, `is_draft`, `is_public`). By making this switch, it'll also allow us to support more databases in the future since the `SET` column type is not part of the SQL standard.

## Progress

Model migration to new QueryBuilder **and** new status convention.

- [ ] ApiKey
- [x] Ban
- [ ] Conversation
- [ ] ConversationEvent
- [x] Country
- [x] Invitation
- [x] Map
- [ ] Match
- [ ] Message
- [x] News
- [x] NewsCategory
- [ ] Notification
- [x] Page
- [x] Permission
- [x] Player
- [ ] Role
- [x] Server
- [x] Team
- [x] Visit

Closes #163 